### PR TITLE
Add [Install] section to jeos-firstboot.service

### DIFF
--- a/files/usr/lib/systemd/system/jeos-firstboot.service
+++ b/files/usr/lib/systemd/system/jeos-firstboot.service
@@ -22,3 +22,6 @@ ExecStart=/usr/lib/jeos-firstboot
 StandardOutput=tty
 StandardInput=tty
 #StandardError=tty
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Use default.target to run regardless of the runlevel.