### PR TITLE
Add udev-settle to wait all udev rules to be run

### DIFF
--- a/files/usr/lib/systemd/system/jeos-firstboot.service
+++ b/files/usr/lib/systemd/system/jeos-firstboot.service
@@ -11,6 +11,7 @@ DefaultDependencies=no
 Conflicts=shutdown.target
 After=systemd-remount-fs.service
 Before=systemd-sysusers.service sysinit.target shutdown.target
+Wants=systemd-udev-settle.service
 ConditionPathIsReadWrite=/etc
 ConditionFirstBoot=yes
 


### PR DESCRIPTION
This is required as Hyper-V and Xen have different console
setups that are required to finish before this service starts
Related to bsc#987589 and bsc#1031618