### PR TITLE
Change default values for ifcfg files bsc#1069782

### DIFF
--- a/files/usr/lib/jeos-firstboot
+++ b/files/usr/lib/jeos-firstboot
@@ -256,7 +256,7 @@ done
 
 for d in ${candidates[@]} ; do
         rm -f "/etc/sysconfig/network/ifcfg-$d" || exit 1
-        printf "STARTMODE=hotplug\nBOOTPROTO=dhcp\nDHCLIENT_SET_HOSTNAME=yes\n" \
+        printf "STARTMODE=auto\nBOOTPROTO=dhcp\n" \
                 > "/etc/sysconfig/network/ifcfg-$d"
         break # one is enough
 done


### PR DESCRIPTION
Making it 'auto' to match leanOS default install and removing the DHCLIENT_SET_HOSTNAME option because of the clash with other config files, described in the bug.