### PR TITLE
Refine locale setup again

### DIFF
--- a/files/usr/lib/jeos-firstboot
+++ b/files/usr/lib/jeos-firstboot
@@ -82,16 +82,6 @@ keytable=''
 locale=''
 password=''
 
-# Console fonts mapping to locales
-# this need to be reworked, check bsc#1094346
-declare -A consolefonts
-consolefonts["el_GR.UTF-8"]="iso07u-16.psfu"
-consolefonts["ru_RU.UTF-8"]="UniCyr_8x16.psf"
-consolefonts["sr_RS.UTF-8"]="UniCyr_8x16.psf"
-consolefonts["uk_UA.UTF-8"]="UniCyr_8x16.psf"
-consolefonts["tg_TJ.UTF-8"]="UniCyr_8x16.psf"
-consolefonts["bg_BG.UTF-8"]="UniCyr_8x16.psf"
-
 let dh_menu=LINES-15
 let dh_text=LINES-5
 
@@ -102,6 +92,10 @@ d(){
     else
 	return $?
     fi
+}
+
+warn(){
+    d --title $"Warning" --msgbox "$1" 6 40
 }
 
 menulist()
@@ -137,17 +131,19 @@ findlocales()
     [ -n "$list" ]
 }
 
-if findlocales && d --default-item "en_US" --menu  $"Select System Locale" 0 0 $dh_menu "${list[@]}"; then
+default="en_US"
+[ -f /etc/locale.conf ] && locale_lang="$(awk -F= '$1 == "LANG" { split($2,fs,"."); print fs[1]; exit }' /etc/locale.conf)"
+[ -n "$locale_lang" ] && default="$locale_lang"
+
+if findlocales && d --default-item "$default" --menu  $"Select System Locale" 0 0 $dh_menu "${list[@]}"; then
 	if [ -n "$result" ]; then
 	    locale="${result}.UTF-8"
 	    systemd_firstboot_args+=("--locale=$locale")
 	    LANG="$locale"
 	    export LANG
-        if [ ${consolefonts[$locale]+_} ]; then
-            run sed -i -e "s/^FONT=.*/FONT=${consolefonts[$locale]}/" /etc/vconsole.conf
-            run sed -i -e "s/^CONSOLE_FONT=.*/CONSOLE_FONT=i\"${consolefonts[$locale]}\"/" /etc/vconsole.conf
-            run /usr/lib/systemd/systemd-vconsole-setup || true # true for nspawn
-        fi
+
+            # Run langset to get consolefont and keymap set up
+            run langset.sh $locale || warn $"Setting the locale failed"
 	fi
 else
 	d --msgbox $"Error setting locale" 0 0
@@ -177,21 +173,31 @@ if [ -e "$EULA_FILE" -a ! -e "${EULA_FILE%/*}/no-acceptance-needed" ]; then
     done
 fi
 
+default="us"
+[ -f /etc/vconsole.conf ] && vconsole_keymap="$(awk -F= '$1 == "KEYMAP" { split($2,fs,"."); print fs[1]; exit }' /etc/vconsole.conf)"
+[ -n "$vconsole-keymap" ] && default="$vconsole_keymap"
+
 if findkeymaps \
-    && d --menu  $"Select Keyboard Layout" 0 0 $dh_menu "${list[@]}"; then
+    && d --default-item "$default" --menu  $"Select Keyboard Layout" 0 0 $dh_menu "${list[@]}"; then
 	if [ -n "$result" ]; then
 	    keytable="$result"
+
+            # Activate the selected keyboard layout
+            run langset.sh "$locale" "$keytable" || warn $"Setting the keyboard layout failed"
 	fi
 else
 	d --msgbox $"Error setting keyboard" 0 0
 fi
+
+default="$(readlink /etc/localtime)"
+default="${default##/usr/share/zoneinfo/}"
 
 # timedatectl doesn't work as dbus is not up yet
 # menulist timedatectl --no-pager list-timezones
 if menulist awk \
     'BEGIN{print "UTC"; sort="sort"}/^#/{next;}{print $3|sort}END{close(sort)}' \
     /usr/share/zoneinfo/zone.tab \
-    && d --menu  $"Select Time Zone" 0 0 $dh_menu "${list[@]}"; then
+    && d --default-item "$default" --menu $"Select Time Zone" 0 0 $dh_menu "${list[@]}"; then
 	if [ -n "$result" ]; then
 	    systemd_firstboot_args+=("--timezone=$result")
 	fi
@@ -199,19 +205,9 @@ else
 	d --msgbox $"error setting timezone" 0 0
 fi
 
-# we need to adjust the keyboard and locale before the password is typed, in
-# case umlauts are used
-if [ -n "$keytable" ]; then
-    echo "KEYMAP=$keytable" | run tee -a /etc/vconsole.conf
-    run sed -i -e "s/^KEYTABLE=.*/KEYTABLE=\"$keytable\"/" /etc/sysconfig/keyboard
-fi
-# FIXME: systemd sets /etc/locale.conf which is ignored
-if [ -n "$locale" ]; then
-    run sed -i -e "s/^RC_LANG=.*/RC_LANG=\"$locale\"/" /etc/sysconfig/language
-    export LANG="$locale"
-fi
+# systemd-firstboot does not set the timezone if it exists, langset.sh created it
+run rm -f /etc/localtime
 run systemd-firstboot "${systemd_firstboot_args[@]}"
-run /usr/lib/systemd/systemd-vconsole-setup || true # true for nspawn
 
 # NOTE: must be last as dialog file is used to set the password
 while true; do
@@ -228,7 +224,7 @@ while true; do
 	fi
     fi
     if [ -z "$password" ]; then
-	d --msgbox $"Warning: No root password set.
+	warn $"Warning: No root password set.
 
 You cannot log in that way. A debug shell will be started on tty9 just this time. Use it to e.g. import your ssh key." 0 0 || true
 	run systemctl start debug-shell.service
@@ -291,7 +287,7 @@ for d in ${candidates[@]} ; do
 done
 
 # Run snapper to setup quota for btrfs
-/usr/bin/snapper --no-dbus setup-quota
+/usr/bin/snapper --no-dbus setup-quota || warn $"Could not setup quota for btrfs"
 
 #d --infobox "Creating snapshot ..." 3 40 || true
 #run snapper --no-dbus -v create -d "Initial Status" --userdata "important=yes" || d --msgbox "snapper failed" 0 0 || true

--- a/files/usr/lib/systemd/system/jeos-firstboot.service
+++ b/files/usr/lib/systemd/system/jeos-firstboot.service
@@ -7,20 +7,23 @@
 
 [Unit]
 Description=SUSE JeOS First Boot Wizard
-DefaultDependencies=no
-Conflicts=shutdown.target
-After=systemd-remount-fs.service
-Before=systemd-tmpfiles-setup.service sysinit.target shutdown.target
-ConditionPathIsReadWrite=/etc
-RequiresMountsFor=/.snapshots
-# Use the same file as yast
+
+# Same as YaST2-Firstboot.service here
+After=apparmor.service local-fs.target plymouth-start.service YaST2-Second-Stage.service
+Conflicts=plymouth-start.service
+Before=getty@tty1.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service
+Before=display-manager.service
 ConditionPathExists=/var/lib/YaST2/reconfig_system
 OnFailure=poweroff.target
 
+# jeos-firstboot starts before network and login though
+Before=network.service systemd-user-sessions.service
+
 [Service]
-Environment=SYSTEMCTL_OPTIONS=--ignore-dependencies TERM=linux
 Type=oneshot
+Environment=SYSTEMCTL_OPTIONS=--ignore-dependencies TERM=linux
 RemainAfterExit=yes
+ExecStartPre=-/usr/bin/plymouth quit
 ExecStart=/usr/lib/jeos-firstboot
 ExecStartPost=/usr/bin/rm -f /var/lib/YaST2/reconfig_system
 StandardOutput=tty

--- a/files/usr/lib/systemd/system/jeos-firstboot.service
+++ b/files/usr/lib/systemd/system/jeos-firstboot.service
@@ -13,13 +13,16 @@ After=systemd-remount-fs.service
 Before=systemd-tmpfiles-setup.service sysinit.target shutdown.target
 ConditionPathIsReadWrite=/etc
 RequiresMountsFor=/.snapshots
-ConditionFirstBoot=yes
+# Use the same file as yast
+ConditionPathExists=/var/lib/YaST2/reconfig_system
+OnFailure=poweroff.target
 
 [Service]
 Environment=SYSTEMCTL_OPTIONS=--ignore-dependencies TERM=linux
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/lib/jeos-firstboot
+ExecStartPost=/usr/bin/rm -f /var/lib/YaST2/reconfig_system
 StandardOutput=tty
 StandardInput=tty
 #StandardError=tty


### PR DESCRIPTION
Use live-langset-data.

This required a rewiring of the jeos-firstboot.service so I also changed the way it's enabled to fix a different bug.