### PR TITLE
Get list of locales from /usr/share/langset/ and remove duplicate "us" keymap

### DIFF
--- a/files/usr/lib/jeos-firstboot
+++ b/files/usr/lib/jeos-firstboot
@@ -112,7 +112,7 @@ menulist()
 #menulist localectl --no-pager list-keymaps
 findkeymaps()
 {
-    list=('us' '')
+    list=()
     local line
     while read line; do
 	    list+=("${line%.map.gz}" '')
@@ -124,9 +124,8 @@ findlocales()
 {
     list=()
     local l
-    for l in /usr/lib/locale/*.utf8; do
-	code=${l#/usr/lib/locale/}
-	list+=("${code/.utf8/}" '')
+    for l in /usr/share/langset/*; do
+	list+=("${l#/usr/share/langset/}" '')
     done
     [ -n "$list" ]
 }


### PR DESCRIPTION
- Only the locales langset knows about can be chosen anyway
- Fixes bsc#1104041