### PR TITLE
reenable console loglevel to the default

### DIFF
--- a/files/usr/lib/jeos-firstboot
+++ b/files/usr/lib/jeos-firstboot
@@ -62,8 +62,9 @@ dialog_out=`mktemp -qt 'firstboot-XXXXXX'`
 cleanup() {
 	echo .oOo.oOo.oOo. > $dialog_out
 	rm -f "$dialog_out"
+	# reenable systemd and kernel logs
 	run kill -s SIGRTMAX-10 1
-	run setterm -msglevel 4 2>/dev/null
+	run setterm -msg on
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
We were setting the msglevel to 4 instead of using
whatever was the current one