### PR TITLE
Allows the skip of timezone and password dialogs

### DIFF
--- a/files/usr/lib/jeos-firstboot
+++ b/files/usr/lib/jeos-firstboot
@@ -296,14 +296,13 @@ if [ -z "$JEOS_TIMEZONE" ]; then
 		/usr/share/zoneinfo/zone.tab \
 	    && d --default-item "$default" --menu $"Select Time Zone" 0 0 $dh_menu "${list[@]}"; then
 	if [ -n "$result" ]; then
-	    systemd_firstboot_args+=("--timezone=$result")
+	    JEOS_TIMEZONE="$result"
 	fi
     else
 	d --msgbox $"error setting timezone" 0 0
     fi
-else
-    systemd_firstboot_args+=("--timezone=$JEOS_TIMEZONE")
 fi
+systemd_firstboot_args+=("--timezone=$JEOS_TIMEZONE")
 
 # systemd-firstboot does not set the timezone if it exists, langset.sh created it
 run rm -f /etc/localtime

--- a/files/usr/lib/jeos-firstboot
+++ b/files/usr/lib/jeos-firstboot
@@ -26,6 +26,10 @@ TEXTDOMAIN='jeos-firstboot'
 . /etc/os-release
 . "$0-functions"
 
+# Read the optional configuration file
+[ -f /usr/share/defaults/jeos-firstboot.conf ] && . /usr/share/defaults/jeos-firstboot.conf
+[ -f /etc/jeos-firstboot.conf ] && . /etc/jeos-firstboot.conf
+
 stty_size() {
     set -- `stty size`; LINES=$1; COLUMNS=$2
     # stty size can return zero when not ready or

--- a/files/usr/lib/jeos-firstboot
+++ b/files/usr/lib/jeos-firstboot
@@ -183,7 +183,7 @@ findlocales()
     [ -n "$list" ]
 }
 
-if [ -z "$LOCALE_PRESET" ]; then
+if [ -z "$JEOS_LOCALE" ]; then
     default="en_US"
     [ -f /etc/locale.conf ] && locale_lang="$(awk -F= '$1 == "LANG" { split($2,fs,"."); print fs[1]; exit }' /etc/locale.conf)"
     [ -n "$locale_lang" ] && default="$locale_lang"
@@ -208,11 +208,11 @@ if [ -z "$LOCALE_PRESET" ]; then
         run langset.sh $locale || warn $"Setting the locale failed"
     fi
 else
-    locale="$LOCALE_PRESET"
+    locale="$JEOS_LOCALE"
     systemd_firstboot_args+=("--locale=$locale")
 fi
 
-if [ -z "$KEYTABLE_PRESET" ]; then
+if [ -z "$JEOS_KEYTABLE" ]; then
     default="us"
     [ -f /etc/vconsole.conf ] && vconsole_keymap="$(awk -F= '$1 == "KEYMAP" { split($2,fs,"."); print fs[1]; exit }' /etc/vconsole.conf)"
     [ -n "$vconsole_keymap" ] && default="$vconsole_keymap"
@@ -245,8 +245,10 @@ if [[ "$(ps h -o tty -p $$)" = tty[0-9]* ]]; then
     start_kmscon["ko"]=1
 
     if [ -n "$locale" -a -n "${start_kmscon[${language}]+_}" ]; then
-        export LOCALE_PRESET="$locale"
-        export KEYTABLE_PRESET="$keytable"
+	# We re-export the variables, as will be inspected when this
+	# script is re-executed in the secondary console
+        export JEOS_LOCALE="$locale"
+        export JEOS_KEYTABLE="$keytable"
 
         if kmscon_available; then
             ret_file="$(mktemp)"
@@ -293,7 +295,7 @@ fi
 default="$(readlink -f /etc/localtime)"
 default="${default##/usr/share/zoneinfo/}"
 
-if [ -z "$TIMEZONE_PRESET" ]; then
+if [ -z "$JEOS_TIMEZONE" ]; then
     # timedatectl doesn't work as dbus is not up yet
     # menulist timedatectl --no-pager list-timezones
     if menulist awk \
@@ -307,7 +309,7 @@ if [ -z "$TIMEZONE_PRESET" ]; then
 	d --msgbox $"error setting timezone" 0 0
     fi
 else
-    timezone="$TIMEZONE_PRESET"
+    timezone="$JEOS_TIMEZONE"
     systemd_firstboot_args+=("--timezone=$timezone")
 fi
 
@@ -315,7 +317,7 @@ fi
 run rm -f /etc/localtime
 run systemd-firstboot "${systemd_firstboot_args[@]}"
 
-if [ -z "$PASSWORD_ALREADY_SET" ]; then
+if [ -z "$JEOS_PASSWORD_ALREADY_SET" ]; then
     # NOTE: must be last as dialog file is used to set the password
     while true; do
 	password=

--- a/files/usr/lib/jeos-firstboot
+++ b/files/usr/lib/jeos-firstboot
@@ -396,7 +396,7 @@ if ! [ -f "$EFI_SYSTAB" ]; then
 fi
 
 # Test if snapper is available
-if [ -x /usr/bin/snapper ]; then
+if [ -x /usr/bin/snapper -a "$(stat --format=%T -f /)" = "btrfs" ]; then
     if ! btrfs qgroup show / &>/dev/null; then
         # Run snapper to setup quota for btrfs
         run /usr/bin/snapper --no-dbus setup-quota || warn $"Could not setup quota for btrfs"

--- a/files/usr/lib/jeos-firstboot
+++ b/files/usr/lib/jeos-firstboot
@@ -311,28 +311,30 @@ fi
 run rm -f /etc/localtime
 run systemd-firstboot "${systemd_firstboot_args[@]}"
 
-# NOTE: must be last as dialog file is used to set the password
-while true; do
-    password=
-    if d --insecure --passwordbox  $"Enter root Password" 0 0; then
-	password="$result"
-	if d --insecure --passwordbox  $"Confirm root Password" 0 0; then
-	    if [ "$password" != "$result" ]; then
-		d --msgbox $"Entered passwords don't match" 5 40 || true
-		continue
+if [ -z "$PASSWORD_ALREADY_SET" ]; then
+    # NOTE: must be last as dialog file is used to set the password
+    while true; do
+	password=
+	if d --insecure --passwordbox  $"Enter root Password" 0 0; then
+	    password="$result"
+	    if d --insecure --passwordbox  $"Confirm root Password" 0 0; then
+		if [ "$password" != "$result" ]; then
+		    d --msgbox $"Entered passwords don't match" 5 40 || true
+		    continue
+		fi
+		# don't use that one as we need to switch locale
+		#systemd_firstboot_args+=("--root-password-file=$dialog_out")
 	    fi
-	    # don't use that one as we need to switch locale
-	    #systemd_firstboot_args+=("--root-password-file=$dialog_out")
 	fi
-    fi
-    if [ -z "$password" ]; then
-	warn $"Warning: No root password set.
+	if [ -z "$password" ]; then
+	    warn $"Warning: No root password set.
 
 You cannot log in that way. A debug shell will be started on tty9 just this time. Use it to e.g. import your ssh key." 0 0 || true
-	run systemctl start debug-shell.service
-    fi
-    break
-done
+	    run systemctl start debug-shell.service
+	fi
+	break
+    done
+fi
 
 if [ -x /usr/bin/SUSEConnect ]; then
     d --msgbox $"Please register this image using your existing SUSE entitlement.

--- a/files/usr/lib/jeos-firstboot
+++ b/files/usr/lib/jeos-firstboot
@@ -104,10 +104,13 @@ sleep 1
 
 systemd_firstboot_args=('--setup-machine-id')
 
+# If the configuration is not loaded and we are in the first terminal
+# instance, make sure that the variables are declared.
+JEOS_LOCALE=${JEOS_LOCALE-}
+JEOS_KEYTABLE=${JEOS_KEYTABLE-}
+
 result=
 list=
-keytable=''
-locale=''
 password=''
 
 let dh_menu=LINES-15
@@ -200,17 +203,11 @@ if [ -z "$JEOS_LOCALE" ]; then
         newlocale="${result}"
     fi
 
-    if [ -n "$newlocale" ]; then
-        locale="${newlocale}.UTF-8"
-        systemd_firstboot_args+=("--locale=$locale")
-
-        # Run langset to get consolefont and keymap set up
-        run langset.sh $locale || warn $"Setting the locale failed"
-    fi
-else
-    locale="$JEOS_LOCALE"
-    systemd_firstboot_args+=("--locale=$locale")
+    JEOS_LOCALE="${newlocale}.UTF-8"
 fi
+
+run langset.sh $JEOS_LOCALE || warn $"Setting the locale failed"
+systemd_firstboot_args+=("--locale=$JEOS_LOCALE")
 
 if [ -z "$JEOS_KEYTABLE" ]; then
     default="us"
@@ -220,24 +217,22 @@ if [ -z "$JEOS_KEYTABLE" ]; then
     if findkeymaps \
         && d --default-item "$default" --menu  $"Select Keyboard Layout" 0 0 $dh_menu "${list[@]}"; then
         if [ -n "$result" ]; then
-            keytable="$result"
+            JEOS_KEYTABLE="$result"
         fi
     else
         d --msgbox $"Error setting keyboard" 0 0
     fi
-else
-    keytable="$JEOS_KEYTABLE"
 fi 
 
-if [ ! -z "$locale" -a ! -z "$keytable" ]; then
+if [ ! -z "$JEOS_LOCALE" -a ! -z "$JEOS_KEYTABLE" ]; then
     # Activate the selected keyboard layout
-    run langset.sh "$locale" "$keytable" || warn $"Setting the keyboard layout failed"
+    run langset.sh "$JEOS_LOCALE" "$JEOS_KEYTABLE" || warn $"Setting the keyboard layout failed"
 fi
 
 
-[ -n "${locale}" ] && language="${locale%%_*}" || language="en"
+[ -n "$JEOS_LOCALE" ] && language="${JEOS_LOCALE%%_*}" || language="en"
 force_english_license=0
-export LANG="$locale"
+export LANG="$JEOS_LOCALE"
 
 if [[ "$(ps h -o tty -p $$)" = tty[0-9]* ]]; then
     # Those languages can't be displayed in the console
@@ -247,12 +242,7 @@ if [[ "$(ps h -o tty -p $$)" = tty[0-9]* ]]; then
     start_kmscon["zh"]=1
     start_kmscon["ko"]=1
 
-    if [ -n "$locale" -a -n "${start_kmscon[${language}]+_}" ]; then
-	# We re-export the variables, as will be inspected when this
-	# script is re-executed in the secondary console
-        export JEOS_LOCALE="$locale"
-        export JEOS_KEYTABLE="$keytable"
-
+    if [ -n "$JEOS_LOCALE" -a -n "${start_kmscon[${language}]+_}" ]; then
         if kmscon_available; then
             ret_file="$(mktemp)"
             kmscon --silent --font-size 10 --palette vga --no-reset-env -l -- /bin/sh -c "$0; echo \$? > $ret_file; kill \$PPID"
@@ -280,8 +270,8 @@ fi
 
 if [ -e "$EULA_FILE" -a ! -e "${EULA_FILE%/*}/no-acceptance-needed" ]; then
     if [ "$force_english_license" = "0" ]; then
-        for i in "${EULA_FILE%.txt}.$locale.txt" \
-                "${EULA_FILE%.txt}.${locale%%.UTF-8}.txt" \
+        for i in "${EULA_FILE%.txt}.${JEOS_LOCALE}.txt" \
+                "${EULA_FILE%.txt}.${JEOS_LOCALE%%.UTF-8}.txt" \
                 "${EULA_FILE%.txt}.${language}.txt"; do
             if [ -e "$i" ]; then
             EULA_FILE="$i"

--- a/files/usr/lib/jeos-firstboot
+++ b/files/usr/lib/jeos-firstboot
@@ -289,17 +289,22 @@ fi
 default="$(readlink -f /etc/localtime)"
 default="${default##/usr/share/zoneinfo/}"
 
-# timedatectl doesn't work as dbus is not up yet
-# menulist timedatectl --no-pager list-timezones
-if menulist awk \
-    'BEGIN{print "UTC"; sort="sort"}/^#/{next;}{print $3|sort}END{close(sort)}' \
-    /usr/share/zoneinfo/zone.tab \
-    && d --default-item "$default" --menu $"Select Time Zone" 0 0 $dh_menu "${list[@]}"; then
+if [ -z "$TIMEZONE_PRESET" ]; then
+    # timedatectl doesn't work as dbus is not up yet
+    # menulist timedatectl --no-pager list-timezones
+    if menulist awk \
+		'BEGIN{print "UTC"; sort="sort"}/^#/{next;}{print $3|sort}END{close(sort)}' \
+		/usr/share/zoneinfo/zone.tab \
+	    && d --default-item "$default" --menu $"Select Time Zone" 0 0 $dh_menu "${list[@]}"; then
 	if [ -n "$result" ]; then
 	    systemd_firstboot_args+=("--timezone=$result")
 	fi
-else
+    else
 	d --msgbox $"error setting timezone" 0 0
+    fi
+else
+    timezone="$TIMEZONE_PRESET"
+    systemd_firstboot_args+=("--timezone=$timezone")
 fi
 
 # systemd-firstboot does not set the timezone if it exists, langset.sh created it

--- a/files/usr/lib/jeos-firstboot
+++ b/files/usr/lib/jeos-firstboot
@@ -312,8 +312,7 @@ if [ -z "$JEOS_TIMEZONE" ]; then
 	d --msgbox $"error setting timezone" 0 0
     fi
 else
-    timezone="$JEOS_TIMEZONE"
-    systemd_firstboot_args+=("--timezone=$timezone")
+    systemd_firstboot_args+=("--timezone=$JEOS_TIMEZONE")
 fi
 
 # systemd-firstboot does not set the timezone if it exists, langset.sh created it

--- a/files/usr/lib/jeos-firstboot
+++ b/files/usr/lib/jeos-firstboot
@@ -221,16 +221,19 @@ if [ -z "$JEOS_KEYTABLE" ]; then
         && d --default-item "$default" --menu  $"Select Keyboard Layout" 0 0 $dh_menu "${list[@]}"; then
         if [ -n "$result" ]; then
             keytable="$result"
-
-                # Activate the selected keyboard layout
-                run langset.sh "$locale" "$keytable" || warn $"Setting the keyboard layout failed"
         fi
     else
         d --msgbox $"Error setting keyboard" 0 0
     fi
 else
-    keytable="$result"
+    keytable="$JEOS_KEYTABLE"
+fi 
+
+if [ ! -z "$locale" -a ! -z "$keytable" ]; then
+    # Activate the selected keyboard layout
+    run langset.sh "$locale" "$keytable" || warn $"Setting the keyboard layout failed"
 fi
+
 
 [ -n "${locale}" ] && language="${locale%%_*}" || language="en"
 force_english_license=0

--- a/files/usr/share/defaults/jeos-firstboot.conf
+++ b/files/usr/share/defaults/jeos-firstboot.conf
@@ -1,6 +1,18 @@
 # Example configuration file for jeos-firstboot
 
+# Valid system locale that will be used in JeOS. If is not set, a
+# dialog box will ask for the system locale.
 # JEOS_LOCALE='en_US'
+
+# Keyboard layout used in the system and during jeos-firstboot. If is
+# not set, a dialog box will ask for the keyboard layout.
 # JEOS_KEYTABLE='en'
+
+# Local timezone of the system. If is not set, a dialog box will ask
+# for the local timezone.
 # JEOS_TIMEZONE='UTC'
+
+# If is set to a nonempty value, the dialog box for setting the
+# initial password for the root user will be skipped. In this case is
+# expected that the root password was set by other means.
 # JEOS_PASSWORD_ALREADY_SET=0

--- a/files/usr/share/defaults/jeos-firstboot.conf
+++ b/files/usr/share/defaults/jeos-firstboot.conf
@@ -1,0 +1,6 @@
+# Example configuration file for jeos-firstboot
+
+# LOCALE_PRESET='en_US'
+# KEYTABLE_PRESET='en'
+# TIMEZONE_PRESET='UTC'
+# PASSWORD_ALREADY_SET=0

--- a/files/usr/share/defaults/jeos-firstboot.conf
+++ b/files/usr/share/defaults/jeos-firstboot.conf
@@ -1,6 +1,6 @@
 # Example configuration file for jeos-firstboot
 
-# LOCALE_PRESET='en_US'
-# KEYTABLE_PRESET='en'
-# TIMEZONE_PRESET='UTC'
-# PASSWORD_ALREADY_SET=0
+# JEOS_LOCALE='en_US'
+# JEOS_KEYTABLE='en'
+# JEOS_TIMEZONE='UTC'
+# JEOS_PASSWORD_ALREADY_SET=0


### PR DESCRIPTION
Add two new variables to jeos-firstboot:

* `TIMEZONE_PRESET`
  Based on `LOCALE_PRESET` and `KEYTABLE_PRESET`, this new variable will affect the `systemd_firstboot_args` array if is set, and will skip the time-zone dialog.

* `PASSWORD_ALREADY_SET`
  If set to a non-zero value, will skip the root password dialog. Is expected that the user is setting the root password via other means, like `config.sh` or the Kiwi `users` XML tag.

Also fix the call of btrfs on non-btrfs file systems.