### PR TITLE
Do not fail when updating bootloader in no-UEFI

### DIFF
--- a/files/usr/lib/jeos-firstboot
+++ b/files/usr/lib/jeos-firstboot
@@ -383,7 +383,9 @@ EFI_SYSTAB="/sys/firmware/efi/systab"
 # Look for EFI dir to see if the machine is booted in UEFI mode
 run modprobe efivars
 if ! [ -f "$EFI_SYSTAB" ]; then
-	run sed -i -e "s/LOADER_TYPE=.*/LOADER_TYPE=grub2/g" /etc/sysconfig/bootloader
+	if [ -f /etc/sysconfig/bootloader ]; then
+		run sed -i -e "s/LOADER_TYPE=.*/LOADER_TYPE=grub2/g" /etc/sysconfig/bootloader
+	fi
 fi
 
 # Test if snapper is available


### PR DESCRIPTION
In non-UEFI JeOS images not always /etc/sysconfig/bootloader is
present. When this system is missing, jeos-firstboot service fail
and shutdown the full machine.