### PR TITLE
Run jeos-firstboot-snapshot after local-fs and ignore systemd-user-sessions

### DIFF
--- a/files/usr/lib/systemd/system/jeos-firstboot-snapshot.service
+++ b/files/usr/lib/systemd/system/jeos-firstboot-snapshot.service
@@ -10,11 +10,11 @@ ConditionPathExists=/var/lib/YaST2/reconfig_system
 # The configuration is already done - so this doesn't make much sense
 #OnFailure=poweroff.target
 
-# jeos-firstboot-snapshot starts between jeos-firstboot and login
+# jeos-firstboot-snapshot starts after jeos-firstboot, time got synced
+# and dbus became available
 Wants=time-sync.target
-Requires=jeos-firstboot.service
+Requires=jeos-firstboot.service dbus.service
 After=jeos-firstboot.service time-sync.target
-Before=systemd-user-sessions.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Failed in weird ways in openQA, "multi-user.target not reached" without any hint as to why.

With this it appears to work, at least once.