### PR TITLE
SUSEConnect: do not show the register dialog on non-SLE distributions

### DIFF
--- a/files/usr/lib/jeos-firstboot
+++ b/files/usr/lib/jeos-firstboot
@@ -330,7 +330,8 @@ You cannot log in that way. A debug shell will be started on tty9 just this time
 	done
 fi
 
-if [ -x /usr/bin/SUSEConnect ]; then
+# Do not show the register on non SLE based distributions
+if [ -x /usr/bin/SUSEConnect -a -z "${ID##sle*}" ]; then
 	d --msgbox $"Please register this image using your existing SUSE entitlement.
 
 As \"root\" use the following command:


### PR DESCRIPTION
In openSUSE based distributions we do not want to show the SUSEConnect dialog when this package is available, as the updates are not related with registration.

For installation media, installing SUSEConnect in openSUSE will make sense.