### PR TITLE
Add JEOS_EULA_ALREADY_AGREED option

### DIFF
--- a/files/usr/lib/jeos-firstboot
+++ b/files/usr/lib/jeos-firstboot
@@ -260,31 +260,33 @@ if [[ "$(ps h -o tty -p $$)" = tty[0-9]* ]]; then
 	fi
 fi
 
-# Find the location of the EULA
-# An EULA in /etc takes precedence
-EULA_FILE=/etc/YaST2/licenses/base/license.txt
-[ -e "${EULA_FILE}" ] || EULA_FILE=/usr/share/licenses/product/base/license.txt
+if [ -z "$JEOS_EULA_ALREADY_AGREED" ]; then
+	# Find the location of the EULA
+	# An EULA in /etc takes precedence
+	EULA_FILE=/etc/YaST2/licenses/base/license.txt
+	[ -e "${EULA_FILE}" ] || EULA_FILE=/usr/share/licenses/product/base/license.txt
 
-# Failsafe: If no license found, quit.
-if ! [ -e "$EULA_FILE" ]; then
-	d --msgbox $"No license found - cannot continue" 6 40
-	exit 1
-fi
+	# Failsafe: If no license found, quit.
+	if ! [ -e "$EULA_FILE" ]; then
+		d --msgbox $"No license found - cannot continue" 6 40
+		exit 1
+	fi
 
-if [ "$force_english_license" = "0" ]; then
-	for i in "${EULA_FILE%.txt}.${JEOS_LOCALE}.txt" \
-			"${EULA_FILE%.txt}.${JEOS_LOCALE%%.UTF-8}.txt" \
-			"${EULA_FILE%.txt}.${language}.txt"; do
-		if [ -e "$i" ]; then
-			EULA_FILE="$i"
-			break
-		fi
+	if [ "$force_english_license" = "0" ]; then
+		for i in "${EULA_FILE%.txt}.${JEOS_LOCALE}.txt" \
+				"${EULA_FILE%.txt}.${JEOS_LOCALE%%.UTF-8}.txt" \
+				"${EULA_FILE%.txt}.${language}.txt"; do
+			if [ -e "$i" ]; then
+				EULA_FILE="$i"
+				break
+			fi
+		done
+	fi
+
+	while ! dialog --backtitle "$PRETTY_NAME" --textbox "$EULA_FILE" $dh_text 85 --and-widget --yesno $"Do you agree with the terms of the license?" 0 0; do
+		d --msgbox $"Can not continue without agreement" 6 40
 	done
 fi
-
-while ! dialog --backtitle "$PRETTY_NAME" --textbox "$EULA_FILE" $dh_text 85 --and-widget --yesno $"Do you agree with the terms of the license?" 0 0; do
-	d --msgbox $"Can not continue without agreement" 6 40
-done
 
 default="$(readlink -f /etc/localtime)"
 default="${default##/usr/share/zoneinfo/}"

--- a/files/usr/share/defaults/jeos-firstboot.conf
+++ b/files/usr/share/defaults/jeos-firstboot.conf
@@ -16,3 +16,9 @@
 # initial password for the root user will be skipped. In this case is
 # expected that the root password was set by other means.
 # JEOS_PASSWORD_ALREADY_SET='yes'
+
+# If set to a nonempty value, the dialog box for accepting the EULA
+# will be skipped. Use this option only when building images (ISO /
+# PXE / OEM) that are part of another product and than can be used
+# when this license was already accepted by other means.
+# JEOS_EULA_ALREADY_AGREED='yes'


### PR DESCRIPTION
We could need to create images that leverage jeos-firstboot to take care
of locale / keyboard or network configuration, and where the image is
already part of a different product.  For example, a PXE boot image
(installed via RPM), that will be used as a component to provisioning
new images in a network.
    
This use case will require no user interaction during the boot process,
and currently there is a dialog that forces the user to accept the EULA
license.
    
This patch add a new option, JEOS_EULA_ALREADY_AGREED, that if set to a
nonempty value, will skip the dialog showed for EULA acceptance. As
commented in the example configuration file, this option is expected to
be used only when the image is part of a different product that contains
an already accepted license.

Fix #63