### PR TITLE
Add JEOS_HIDE_SUSECONNECT option

### DIFF
--- a/files/usr/lib/jeos-firstboot
+++ b/files/usr/lib/jeos-firstboot
@@ -332,8 +332,9 @@ You cannot log in that way. A debug shell will be started on tty9 just this time
 	done
 fi
 
-# Do not show the register on non SLE based distributions
-if [ -x /usr/bin/SUSEConnect -a -z "${ID##sle*}" ]; then
+# Do not show the register on non SLE based distributions or if is
+# globally disabled
+if [ -x /usr/bin/SUSEConnect -a -z "${ID##sle*}" -a -z "${JEOS_HIDE_SUSECONNECT}" ]; then
 	d --msgbox $"Please register this image using your existing SUSE entitlement.
 
 As \"root\" use the following command:

--- a/files/usr/share/defaults/jeos-firstboot.conf
+++ b/files/usr/share/defaults/jeos-firstboot.conf
@@ -22,3 +22,8 @@
 # PXE / OEM) that are part of another product and than can be used
 # when this license was already accepted by other means.
 # JEOS_EULA_ALREADY_AGREED='yes'
+
+# If set to a nonempty value, the dialog box for showing the
+# SUSEConnect help will not be displayed. By default this dialog is
+# present when SUSEConnect is installed on SLE systems.
+JEOS_HIDE_SUSECONNECT='yes'


### PR DESCRIPTION
In SLE based images where SUSEConnect is available, a dialog is shown to
the user to remember the registration of the product in order to fetch
future updates.

This commit add a new option that, if enabled, will hide the dialog and
avoid this user interaction.

Fix #65 