### PR TITLE
Drop the info dialog about glibc-locale (jsc#SLE-15348)

### DIFF
--- a/files/usr/sbin/jeos-firstboot
+++ b/files/usr/sbin/jeos-firstboot
@@ -196,9 +196,8 @@ if [ -z "$JEOS_LOCALE" ]; then
 	newlocale="$default"
 	if ! findlocales; then
 		d --msgbox $"No locales found" 0 0
-	elif [ "${#list[@]}" -eq 2 ]; then
+	elif [ "${#list[@]}" -eq 2 ]; then # Only a single entry
 		newlocale="${list[0]}"
-		d --msgbox $"Locale set to $newlocale.\nTo change to a different one, install glibc-locale and use\n'localectl set-locale LANG=ex_AMPLE.UTF-8'." 8 50
 	else
 		d --default-item "$default" --menu $"Select system locale" 0 0 $dh_menu "${list[@]}"
 		newlocale="${result}"


### PR DESCRIPTION
This belongs in the documentation instead, which saves one mandatory
interaction on the first boot.