### PR TITLE
Improve menu appearance

### DIFF
--- a/files/usr/share/jeos-firstboot/jeos-firstboot-dialogs
+++ b/files/usr/share/jeos-firstboot/jeos-firstboot-dialogs
@@ -21,7 +21,7 @@ dialog_locale()
         elif [ "${#list[@]}" -eq 2 ]; then # Only a single entry
                 newlocale="${list[0]}"
         else
-                d --default-item "$default" --menu $"Select system locale" 0 0 $dh_menu "${list[@]}"
+                d --default-item "$default" --menu $"Select system locale" 0 0 "$(menuheight ${#list[@]})" "${list[@]}"
                 newlocale="${result}"
         fi
 
@@ -35,7 +35,7 @@ dialog_keytable()
         [ -n "$vconsole_keymap" ] && default="$vconsole_keymap"
 
         if findkeymaps \
-                && d --default-item "$default" --menu  $"Select keyboard layout" 0 0 $dh_menu "${list[@]}"; then
+                && d --default-item "$default" --menu  $"Select keyboard layout" 0 0 "$(menuheight ${#list[@]})" "${list[@]}"; then
                 if [ -n "$result" ]; then
                         JEOS_KEYTABLE="$result"
                 fi
@@ -53,7 +53,7 @@ dialog_timezone()
 	if menulist awk \
 		'BEGIN{print "UTC"; sort="sort"}/^#/{next;}{print $3|sort}END{close(sort)}' \
 		/usr/share/zoneinfo/zone.tab \
-		&& d --default-item "$default" --menu $"Select time zone" 0 0 $dh_menu "${list[@]}"; then
+		&& d --default-item "$default" --menu $"Select time zone" 0 0 "$(menuheight ${#list[@]})" "${list[@]}"; then
 			if [ -n "$result" ]; then
 				JEOS_TIMEZONE="$result"
 			fi

--- a/files/usr/share/jeos-firstboot/jeos-firstboot-functions
+++ b/files/usr/share/jeos-firstboot/jeos-firstboot-functions
@@ -76,7 +76,7 @@ d(){
 			;;
 		  1)
 			echo "$(xargs -a "$dialog_out")" >/var/log/jeos
-			dialog --yesno $"Do you really want to quit?" 0 0 && exit 1
+			dialog --backtitle "$PRETTY_NAME" --yesno $"Do you really want to quit?" 0 0 && exit 1
 			continue
 			;;
 		  255)
@@ -84,11 +84,11 @@ d(){
 			echo "$(xargs -a "$dialog_out")" >/var/log/jeos
 			result_error="$(xargs -a "$dialog_out")"
 			if [ -z "$result_error" ]; then
-				dialog --yesno $"Do you really want to quit?" 0 0 && exit 1
+				dialog --backtitle "$PRETTY_NAME" --yesno $"Do you really want to quit?" 0 0 && exit 1
 				continue
 			fi
 			logger -p err -t jeos-firstboot "$result_error"
-			dialog --msgbox $"Exiting due to error, please check the system log" 0 0
+			dialog --backtitle "$PRETTY_NAME" --msgbox $"Exiting due to error, please check the system log" 0 0
 			exit 2
 			;;
 		esac

--- a/files/usr/share/jeos-firstboot/jeos-firstboot-functions
+++ b/files/usr/share/jeos-firstboot/jeos-firstboot-functions
@@ -99,6 +99,13 @@ warn(){
 	d --title $"Warning" --msgbox "$1" 6 40
 }
 
+# Given the number of total item pairs, outputs the number of items to display at once
+menuheight() {
+	local height=$(($1 / 2))
+	[ "$height" -le "$dh_menu" ] || height="$dh_menu"
+	echo $height
+}
+
 # localectl --no-pager list-keymaps does not list aliases (symlinks), but those are used
 # by YaST/langset.sh, so we need to show them.
 findkeymaps()

--- a/files/usr/share/jeos-firstboot/modules/raspberrywifi
+++ b/files/usr/share/jeos-firstboot/modules/raspberrywifi
@@ -43,7 +43,7 @@ raspberrywifi_get_wlan_networks()
 
 raspberrywifi_wlan_error()
 {
-	dialog --title $"Error" --yesno $"$1\n\nDo you want to retry?" 0 0
+	dialog --backtitle "$PRETTY_NAME" --title $"Error" --yesno $"$1\n\nDo you want to retry?" 0 0
 }
 
 is_raspberry()
@@ -128,7 +128,7 @@ EOF
 
     run ifdown $wlan_device &>/dev/null || true
     if ! run ifup $wlan_device &>/dev/null; then
-        if dialog --yesno $"Connection failed, do you wish to retry?" 0 0; then
+        if dialog --backtitle "$PRETTY_NAME" --yesno $"Connection failed, do you wish to retry?" 0 0; then
             continue
         fi
     fi
@@ -141,7 +141,7 @@ done
 raspberrywifi_systemd_firstboot()
 {
 	if is_raspberry && stat -t /sys/class/net/*/wireless &> /dev/null; then
-		if dialog --yesno $"Configure wireless network?" 0 0; then
+		if dialog --backtitle "$PRETTY_NAME" --yesno $"Configure wireless network?" 0 0; then
 			config_wireless=true
 		fi
 	fi

--- a/files/usr/share/jeos-firstboot/modules/raspberrywifi
+++ b/files/usr/share/jeos-firstboot/modules/raspberrywifi
@@ -68,11 +68,11 @@ do
     if [ "${#list[@]}" -eq "2" ]; then
         wlan_device="${list[0]}"
     else
-        d --menu  $"Select wireless card to configure" 0 0 $dh_menu "${list[@]}"
+        d --menu  $"Select wireless card to configure" 0 0 "$(menuheight ${#list[@]})" "${list[@]}"
         wlan_device="${result}"
     fi
 
-    if raspberrywifi_get_wlan_networks && d --menu  $"Select wireless network to connect" 0 0 $dh_menu "${list[@]}"; then
+    if raspberrywifi_get_wlan_networks && d --menu  $"Select wireless network to connect" 0 0 "$(menuheight ${#list[@]})" "${list[@]}"; then
         wlan_network="$result"
     else
         if raspberrywifi_wlan_error $"Error listing wireless networks"; then
@@ -81,7 +81,8 @@ do
         break
     fi
 
-    d --menu $"Select authentication mode" 0 0 $dh_menu $"WPA-PSK" '' $"WPA-EAP" '' $"Open" ''
+    list=($"WPA-PSK" '' $"WPA-EAP" '' $"Open" '')
+    d --menu $"Select authentication mode" 0 0 "$(menuheight ${#list[@]})" "${list[@]}"
     wlan_auth_mode="$result"
 
     wlan_auth_mode_conf=


### PR DESCRIPTION
Consistent appearance and less empty space inside the dialog.

While `dialog --menu` allows to specify the total dialog width, height and menu item count, I was unable to find a way to get the dialog box just small enough to contain the description and menu items. There are always two empty lines below the menu list.

Everything automatic results in empty lines and will overflow the backtitle if there are too many items:

 `dialog --menu "Choose wisely" 0 0 0 Value1 "" Value2 ""`:
![Screenshot_20210311_163552](https://user-images.githubusercontent.com/1622084/110812380-da52fe00-8287-11eb-8eb2-eb612bef9c83.png)

The overflowing can be avoided by setting the menu height explicitly, which is what this PR does, but the empty lines remain:

 `dialog --menu "Choose wisely" 0 0 2 Value1 "" Value2 ""`:
![Screenshot_20210311_163552](https://user-images.githubusercontent.com/1622084/110812380-da52fe00-8287-11eb-8eb2-eb612bef9c83.png)

By specifying the dialog height as items+5, the empty lines disappear:

`dialog --menu "Choose wisely" 7 0 0 Value1 "" Value2 ""`
![Screenshot_20210311_163848](https://user-images.githubusercontent.com/1622084/110812868-433a7600-8288-11eb-8d54-1ee4eac5d767.png)

For some reason the dialog height is ignored when there are more items than can fit - it fills the entire screen anyway!
`dialog --menu "Choose wisely" 20 0 0 $(seq 1 100)`
(screenshot omitted)

However, by specifying the menu item height explicitly as well, it's suddenly honoured again, even if the menu height is too big to fit:
`dialog --menu "Choose wisely" 20 0 30 $(seq 1 100)`
![Screenshot_20210311_164410](https://user-images.githubusercontent.com/1622084/110813672-0327c300-8289-11eb-8614-8c3a9b841e98.png)

The behaviour gets really weird in that case though, because
`dialog --menu "Choose wisely" 7 0 0 Value1 "" Value2 ""` and `dialog --menu "Choose wisely" 7 0 2 Value1 "" Value2 ""` behave differently, even though they shouldn't. I assume this is because of the two empty lines at the bottom.

Any idea?

Marked as draft because I didn't check it inside jeos-firstboot yet, only outside.