### PR TITLE
Introduce welcome screen for console switching

### DIFF
--- a/files/usr/lib/systemd/system/jeos-firstboot.service
+++ b/files/usr/lib/systemd/system/jeos-firstboot.service
@@ -11,7 +11,7 @@ Description=SUSE JeOS First Boot Wizard
 # Same as YaST2-Firstboot.service here
 After=apparmor.service local-fs.target plymouth-start.service YaST2-Second-Stage.service
 Conflicts=plymouth-start.service
-Before=getty@tty1.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service
+Before=getty@tty1.service serial-getty@hvc0.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service serial-getty@ttyAMA0.service
 Before=display-manager.service
 ConditionPathExists=/var/lib/YaST2/reconfig_system
 OnFailure=poweroff.target

--- a/files/usr/sbin/jeos-firstboot
+++ b/files/usr/sbin/jeos-firstboot
@@ -26,6 +26,7 @@ TEXTDOMAIN='jeos-firstboot'
 . /etc/os-release
 . "/usr/share/jeos-firstboot/jeos-firstboot-functions"
 . "/usr/share/jeos-firstboot/jeos-firstboot-dialogs"
+. "/usr/share/jeos-firstboot/welcome-screen"
 
 # Read the optional configuration file
 [ -f /usr/share/defaults/jeos-firstboot.conf ] && . /usr/share/defaults/jeos-firstboot.conf
@@ -89,6 +90,7 @@ JEOS_LOCALE=${JEOS_LOCALE-}
 JEOS_KEYTABLE=${JEOS_KEYTABLE-}
 
 if [ -z "$JEOS_LOCALE" ]; then
+    welcome_screen_with_console_switch
     dialog_locale
 fi
 
@@ -98,6 +100,7 @@ apply_locale
 systemd_firstboot_args+=("--locale=$JEOS_LOCALE")
 
 if [ -z "$JEOS_KEYTABLE" ]; then
+    welcome_screen_with_console_switch
     dialog_keytable
 fi 
 
@@ -125,7 +128,7 @@ fbiterm_available() {
         return 0
 }
 
-if [[ "$(ps h -o tty -p $$)" = tty[0-9]* ]]; then
+if [[ "$(resolve_tty "$(tty)")" =~ /dev/tty[0-9]+ ]]; then
 	# Those languages can't be displayed in the console
 	declare -A start_kmscon
 	start_kmscon["cs"]=1
@@ -151,6 +154,8 @@ if [[ "$(ps h -o tty -p $$)" = tty[0-9]* ]]; then
 fi
 
 if [ -z "$JEOS_EULA_ALREADY_AGREED" ]; then
+	welcome_screen_with_console_switch
+
 	# Find the location of the EULA
 	# An EULA in /etc takes precedence
 	EULA_FILE=/etc/YaST2/licenses/base/license.txt
@@ -179,6 +184,7 @@ if [ -z "$JEOS_EULA_ALREADY_AGREED" ]; then
 fi
 
 if [ -z "$JEOS_TIMEZONE" ]; then
+    welcome_screen_with_console_switch
     dialog_timezone
 fi
 
@@ -189,12 +195,14 @@ run rm -f /etc/localtime
 run systemd-firstboot "${systemd_firstboot_args[@]}"
 
 if [ -z "$JEOS_PASSWORD_ALREADY_SET" ]; then
+    welcome_screen_with_console_switch
     dialog_password
 fi
 
 # Do not show the register on non SLE based distributions or if is
 # globally disabled
 if [ -x /usr/bin/SUSEConnect -a -z "${ID##sle*}" -a -z "${JEOS_HIDE_SUSECONNECT}" ]; then
+	welcome_screen_with_console_switch
 	d --msgbox $"Please register this image using your existing SUSE entitlement.
 
 As \"root\" use the following command:

--- a/files/usr/share/defaults/jeos-firstboot.conf
+++ b/files/usr/share/defaults/jeos-firstboot.conf
@@ -27,3 +27,8 @@
 # SUSEConnect help will not be displayed. By default this dialog is
 # present when SUSEConnect is installed on SLE systems.
 # JEOS_HIDE_SUSECONNECT='yes'
+
+# If enabled, jeos-firstboot shows a welcome screen on all consoles and
+# continues on the console where Ok was pressed. When disabled, only the
+# active console (last "console=" on the kernel cmdline) is used.
+JEOS_ASK_CONSOLE=1

--- a/files/usr/share/jeos-firstboot/jeos-firstboot-functions
+++ b/files/usr/share/jeos-firstboot/jeos-firstboot-functions
@@ -6,6 +6,9 @@ stty_size() {
 		LINES=24
 		COLUMNS=80
 	fi
+
+	let dh_menu=LINES-15
+	let dh_text=LINES-5
 }
 stty_size
 
@@ -13,9 +16,6 @@ result=
 list=
 password=''
 modules=()
-
-let dh_menu=LINES-15
-let dh_text=LINES-5
 
 if pushd "/usr/share/jeos-firstboot/modules" &>/dev/null; then
         for module in *; do
@@ -143,4 +143,19 @@ apply_password()
 		run echo "root:$password" | run /usr/sbin/chpasswd
 	fi
 }
+
+# Resolves /dev/console and /dev/tty0
+resolve_tty() {
+        local tty="$1"
+        if [ "$tty" = "/dev/console" ]; then
+                tty=$(awk '{printf "/dev/%s", $NF}' /sys/class/tty/console/active)
+        fi
+
+        if [ "$tty" = "/dev/tty0" ]; then
+                printf "/dev/%s" "$(cat /sys/class/tty/tty0/active)"
+        else
+                echo -n "$tty"
+        fi
+}
+
 # vim: syntax=sh

--- a/files/usr/share/jeos-firstboot/jeos-firstboot-functions
+++ b/files/usr/share/jeos-firstboot/jeos-firstboot-functions
@@ -44,23 +44,6 @@ call_module_hook() {
         return 0
 }
 
-kmscon_available() {
-	# kmscon itself is installed
-	kmscon --help >/dev/null 2>&1 || return 1
-	# At least one monospace font is available
-	[ -n "$(fc-match "monospace" 2>/dev/null)" ] || return 1
-
-	return 0
-}
-
-fbiterm_available() {
-	# fbiterm itself is installed
-	fbiterm --help >/dev/null 2>&1 || return 1
-	# fbiterm comes with its own fallback font
-
-	return 0
-}
-
 dialog_out=`mktemp -qt 'firstboot-XXXXXX'`
 d(){
 	retval=

--- a/files/usr/share/jeos-firstboot/welcome-screen
+++ b/files/usr/share/jeos-firstboot/welcome-screen
@@ -1,0 +1,116 @@
+# Function to allow showing dialogs (or other stuff) on all consoles.
+# At its core, it works by spawning processes with the given command on each
+# console and waits for them to finish. If any exits with an exit status other
+# than 254, the others are killed and the status returned.
+#
+# The inner workings are a bit complex, mostly to workaround bash not being
+# able to wait for any process to exit, returning pid + status. It can either
+# wait for multiple processes (PIDs) to exit or return the exit status of any
+# process, but not the corresponding PID. There is no way to deal with
+# background processes which exit before "wait" was called. In the case that
+# there is no background process anymore, "wait" simply returns 0.
+# As a workaround, the spawned background processes stay alive until killed
+# explicitly and report their exit status and console through a FIFO.
+
+# Directory the fifo for IPC is stored in. Managed by on_all_consoles.
+fifodir=
+# Console of the successful console_subproc
+console=
+
+# Internal helper used by on_all_consoles.
+# This function is called for each console and basically runs "$@" on the
+# console given in $1 and writes its exit status into the fifo.
+# Bash doesn't forward signals to its child processes, instead that needs
+# to be done explicitly. This is necessary for "dialog" to restore the tty.
+# Note: When passing a function as parameter, make sure to not spawn
+# subprocesses, i.e. use exec when possible.
+console_subproc() {
+	local console="$1"
+	shift
+	"$@" <>"$console" >&0 &
+	pid=$!
+	trap 'set +e; kill $pid; wait $pid; dialog --clear <>"$console" >&0; exit 0' SIGTERM
+	ret=0
+	wait $pid || ret=$?
+	# Undo the trap to not kill the already dead process and also
+	# avoid waiting for the current process (sleep 1) before handling it.
+	trap - SIGTERM
+	echo "$ret $console" > "${fifodir}/fifo"
+	# Stay around until explicitly killed.
+	while :; do sleep 1; done
+}
+
+on_all_consoles() {
+	# Needed to tell apart errors and escape
+	export DIALOG_ERROR=254
+	# The linux fbcon uses this, most serial consoles should be fine too
+	export TERM=linux
+
+	# Create a FIFO for communicating the status
+	fifodir="$(mktemp -d)"
+	mkfifo "${fifodir}/fifo"
+
+	# For every active console, create a background process
+	local pids=()
+	local currenttty="$(resolve_tty "$(tty)")"
+	for console in $(cat /sys/class/tty/console/active); do
+		console="/dev/${console}"
+		[ -r "$console" ] || continue
+		# Skip current tty
+		[ "$(resolve_tty "$console")" = "$currenttty" ] && continue
+		console_subproc "$console" "$@" &
+		pids+=($!)
+	done
+
+	# Also for the current tty
+	console_subproc "$currenttty" "$@" &
+	pids+=($!)
+
+	# Wait for either all processes to fail or one to succeed
+	local finished=0
+	while read status console < "${fifodir}/fifo"; do
+		((finished++)) || :
+		[ $finished -eq ${#pids[@]} ] && break
+		[ $status -eq 254 ] || break
+	done
+
+	# All done, kill remaining processes
+	kill "${pids[@]}" || :
+	wait "${pids[@]}" || :
+
+	rm -r "$fifodir"
+	fifodir=
+
+	return $status
+}
+
+# If JEOS_ASK_CONSOLE is not 0, show the "welcome" screen and switch to the
+# console where it was acked on.
+welcome_screen_with_console_switch() {
+	[ "${JEOS_ASK_CONSOLE-0}" -eq "0" ] && return 0
+
+	# Only ask once
+	[ "${JEOS_CONSOLE_ASKED-0}" -eq "1" ] && return 0
+	export JEOS_CONSOLE_ASKED=1
+
+	while true; do
+		ret=0
+		on_all_consoles dialog --backtitle "$PRETTY_NAME" --title $"JeOS Firstboot" --ok-label $"Start" --msgbox $"Welcome to $PRETTY_NAME"'!\nThe initial configuration takes just a few steps.' 0 0 || ret=$?
+		if [ "$ret" -eq 0 ]; then
+			break;
+		elif [ "$ret" -eq 254 ]; then
+			# Error? Just continue and fail later
+			return;
+		else
+			if on_all_consoles dialog --backtitle "$PRETTY_NAME" --yesno $"Do you really want to quit?" 0 0; then
+				exit 1
+			fi
+		fi
+	done
+
+	# Move stdio to the console
+	if [ "$console" != "$(tty)" ]; then
+		exec 0<>"$console" 1>&0
+		stty_size
+	fi
+}


### PR DESCRIPTION
Currently, jeos-firstboot is only on the active console, which can only be
configured by changing the kernel cmdline. This commit introduces a welcome
dialog which is shown on all active consoles (from /proc/consoles) and it
continues on the console where the welcome screen was accepted.

![Screenshot_20210512_102352](https://user-images.githubusercontent.com/1622084/117943245-354ab500-b30c-11eb-9d65-4c73f6cd5874.png)

~WIP because:~

- [x] Welcome screen needs proper text
- [x] When started from systemd, it gets `/dev/console` as tty. That's not handled properly yet.
- [ ] If there's just a single entry in `/proc/consoles`, skip the screen?