### PR TITLE
Skip the lo interface when probing for DHCP

### DIFF
--- a/files/usr/share/jeos-firstboot/jeos-firstboot-dialogs
+++ b/files/usr/share/jeos-firstboot/jeos-firstboot-dialogs
@@ -88,16 +88,18 @@ dialog_network()
 
 	shopt -s nullglob
 
-	for net_path in /sys/class/net/* ; do
-		test -f "$net_path" && continue # skip bonding_masters file
+	for net_path in /sys/class/net/*; do
+		[ -d "$net_path" ] || continue # skip bonding_masters file
+
+		net_device=${net_path##*/}
+
+		[ "$net_device" = "lo" ] && continue
 
 		# Only devices having ID_NET_NAME.* attrs
 		# Ignore errors if udev not available
 		udevadm info -q property -p "$net_path" 2>/dev/null | grep -qs ID_NET_NAME || continue
 		# But don't touch WLAN interfaces
 		udevadm info -q property -p "$net_path" | grep -qs "DEVTYPE=wlan" && continue
-
-		net_device=${net_path##*/}
 
 		unset IPADDR
 		eval `wicked test dhcp4 "$net_device" 2>/dev/null | grep -E "^IPADDR="`


### PR DESCRIPTION
It's unnecessary and causes wicked to write an error into the journal.