### PR TITLE
Use the snapper config to determine whether to run setup-quota (boo#1192940)

### DIFF
--- a/files/usr/sbin/jeos-firstboot
+++ b/files/usr/sbin/jeos-firstboot
@@ -228,8 +228,9 @@ fi
 
 # Test if snapper is available
 if [ -x /usr/bin/snapper -a "$(stat --format=%T -f /)" = "btrfs" ]; then
-	if ! btrfs qgroup show / &>/dev/null; then
-		# Run snapper to setup quota for btrfs
+	# Search for non-empty QGROUP value in the config, if not found ...
+	if ! grep -qE 'QGROUP="[^"]' /etc/snapper/configs/root; then
+		# ... run snapper to setup quota for btrfs
 		run /usr/bin/snapper --no-dbus setup-quota || warn $"Could not setup quota for btrfs"
 	fi
 fi


### PR DESCRIPTION
It's possible that btrfs quotas are enabled, but the snapper-specific
configuration wasn't done yet. Check for the QGROUP snapper config directly
and call snapper setup-quota if not set. It can deal with already enabled
btrfs quotas as well.