### PR TITLE
Drop call to snapper setup-quota, kiwi does that meanwhile

### DIFF
--- a/files/usr/sbin/jeos-firstboot
+++ b/files/usr/sbin/jeos-firstboot
@@ -226,12 +226,4 @@ if ! [ -f "$EFI_SYSTAB" ]; then
 	fi
 fi
 
-# Test if snapper is available
-if [ -x /usr/bin/snapper -a "$(stat --format=%T -f /)" = "btrfs" ]; then
-	if ! btrfs qgroup show / &>/dev/null; then
-		# Run snapper to setup quota for btrfs
-		run /usr/bin/snapper --no-dbus setup-quota || warn $"Could not setup quota for btrfs"
-	fi
-fi
-
 call_module_hook post


### PR DESCRIPTION
Alternative to https://github.com/openSUSE/jeos-firstboot/pull/84.

Intentionally not mentioning boo#1192940 because this just removes already unused code...