### PR TITLE
Skip broken consoles (bsc#1195975)

### DIFF
--- a/files/usr/share/jeos-firstboot/welcome-screen
+++ b/files/usr/share/jeos-firstboot/welcome-screen
@@ -56,6 +56,9 @@ on_all_consoles() {
 	for console in $(cat /sys/class/tty/console/active); do
 		console="/dev/${console}"
 		[ -r "$console" ] || continue
+		# Skip consoles which aren't ready, e.g. return EIO.
+		# For those, dialog would switch to /dev/tty as fallback.
+		stty size <>"$console" &>/dev/null || continue
 		# Skip current tty
 		[ "$(resolve_tty "$console")" = "$currenttty" ] && continue
 		console_subproc "$console" "$@" &

--- a/files/usr/share/jeos-firstboot/welcome-screen
+++ b/files/usr/share/jeos-firstboot/welcome-screen
@@ -79,7 +79,7 @@ on_all_consoles() {
 
 	# All done, kill remaining processes
 	kill "${pids[@]}" || :
-	wait "${pids[@]}" || :
+	wait "${pids[@]}" 2>/dev/null || :
 
 	rm -r "$fifodir"
 	fifodir=


### PR DESCRIPTION
Currently it starts dialog for all consoles listed in /proc/consoles, but
some of them might not be working (e.g. not set up, see also bsc#1175514#c26).
When dialog is used on one of those consoles, it attempts to use stderr first
and if even that fails, /dev/tty. As a result, starting dialog on a broken
console causes a conflict with dialog on a working console, and weird behaviour
occurs.

Use "stty size" to check whether the console is usable before starting dialog.