### PR TITLE
Proper NetworkManager support

### DIFF
--- a/files/usr/lib/systemd/system/jeos-firstboot.service
+++ b/files/usr/lib/systemd/system/jeos-firstboot.service
@@ -16,8 +16,11 @@ Before=display-manager.service
 ConditionPathExists=/var/lib/YaST2/reconfig_system
 OnFailure=poweroff.target
 
-# jeos-firstboot starts before network and login though
-Before=network.service systemd-user-sessions.service
+# jeos-firstboot starts before wicked and login though.
+# It writes wicked configuration manually
+Before=wicked.service systemd-user-sessions.service
+# For NM it uses nmcli, so NM needs to be running
+After=NetworkManager.service
 
 # The existence of this file reflects whether cloud-init's systemd-generator enables cloud-init.
 # If it does not exist, cloud-init won't run, so it's our turn.

--- a/files/usr/sbin/jeos-config
+++ b/files/usr/sbin/jeos-config
@@ -54,10 +54,18 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Get a list of all config modules
+config_modules=()
+for module in "${modules[@]}"; do
+	if module_has_hook "$module" "jeos_config"; then
+		config_modules+=("${module}")
+	fi
+done
+
 select_config()
 {
 	modules_order=("locale" '' "keytable" '' "timezone" '' "password" '')
-	for module in "${modules[@]}"; do
+	for module in "${config_modules[@]}"; do
 		modules_order+=("${module}" '')
 	done
 
@@ -75,7 +83,7 @@ Configure system settings using an interactive dialog
 	keytable	Show configuration for keyboard
 	timezone	Show configuration for timezone
 	password	Show configuration for password
-$(for module in "${modules[@]}"; do
+$(for module in "${config_modules[@]}"; do
 	echo "	${module}	Show configuration for ${module}"
 done)
 EOF

--- a/files/usr/sbin/jeos-config
+++ b/files/usr/sbin/jeos-config
@@ -56,7 +56,7 @@ trap cleanup EXIT
 
 select_config()
 {
-	modules_order=("locale" '' "keytable" '' "timezone" '' "password" '' "network" '')
+	modules_order=("locale" '' "keytable" '' "timezone" '' "password" '')
 	for module in "${modules[@]}"; do
 		modules_order+=("${module}" '')
 	done
@@ -75,7 +75,6 @@ Configure system settings using an interactive dialog
 	keytable	Show configuration for keyboard
 	timezone	Show configuration for timezone
 	password	Show configuration for password
-	network		Show configuration for network
 $(for module in "${modules[@]}"; do
 	echo "	${module}	Show configuration for ${module}"
 done)
@@ -124,20 +123,6 @@ case "$subcommand" in
 		dialog_timezone
 		timedatectl set-timezone "$JEOS_TIMEZONE"
 		;;	
-	network)
-		if [ "$(current_network_service)" = "NetworkManager" ]; then
-			nmtui
-			exit 0
-		fi
-
-		if ! d --yesno $"This will create a new network configuration from scratch,
-all connections will be lost.\nDo you want to continue?" 7 50; then
-			exit 0
-		fi
-		dialog_network
-		d --infobox $"Restarting network ..." 3 26 || true
-		systemctl restart network
-		;;
 	password)
 		dialog_password
 		apply_password

--- a/files/usr/sbin/jeos-firstboot
+++ b/files/usr/sbin/jeos-firstboot
@@ -215,11 +215,6 @@ Without registration this instance does not have access to updates and
 security fixes." 0 0 || true
 fi
 
-## Configure initial network settings
-if [ "$(current_network_service)" != "NetworkManager" ]; then
-	dialog_network
-fi
-
 call_module_hook systemd_firstboot
 
 d --infobox $"Applying firstboot settings ..." 3 40 || true

--- a/files/usr/share/jeos-firstboot/jeos-firstboot-dialogs
+++ b/files/usr/share/jeos-firstboot/jeos-firstboot-dialogs
@@ -82,38 +82,4 @@ You cannot log in that way. A debug shell will be started on tty9 just this time
 	done
 }
 
-dialog_network()
-{
-	d --infobox $"Collecting network info ..." 3 33
-
-	shopt -s nullglob
-
-	for net_path in /sys/class/net/*; do
-		[ -d "$net_path" ] || continue # skip bonding_masters file
-
-		net_device=${net_path##*/}
-
-		[ "$net_device" = "lo" ] && continue
-
-		# Only devices having ID_NET_NAME.* attrs
-		# Ignore errors if udev not available
-		udevadm info -q property -p "$net_path" 2>/dev/null | grep -qs ID_NET_NAME || continue
-		# But don't touch WLAN interfaces
-		udevadm info -q property -p "$net_path" | grep -qs "DEVTYPE=wlan" && continue
-
-		unset IPADDR
-		eval `wicked test dhcp4 "$net_device" 2>/dev/null | grep -E "^IPADDR="`
-		ip link set down "$net_device" # set link down after probe once done
-
-		# Create a configuration file for each interface that provides
-		# an IPADDR
-		if [ -n "$IPADDR" ]; then
-			printf "STARTMODE=auto\nBOOTPROTO=dhcp\n" \
-				> "/etc/sysconfig/network/ifcfg-$net_device"
-		fi
-	done
-	
-	run sed -i -E 's/^DHCLIENT(6?)_SET_HOSTNAME=.*$/DHCLIENT\1_SET_HOSTNAME=yes/' /etc/sysconfig/network/dhcp
-}
-
 # vim: syntax=sh

--- a/files/usr/share/jeos-firstboot/jeos-firstboot-functions
+++ b/files/usr/share/jeos-firstboot/jeos-firstboot-functions
@@ -162,11 +162,4 @@ resolve_tty() {
         fi
 }
 
-# Returns the basename of the target of network.service,
-# e.g. "wicked" or "NetworkManager"
-current_network_service()
-{
-	systemctl show -P Id network.service | cut -d. -f1
-}
-
 # vim: syntax=sh

--- a/files/usr/share/jeos-firstboot/jeos-firstboot-functions
+++ b/files/usr/share/jeos-firstboot/jeos-firstboot-functions
@@ -26,6 +26,13 @@ if pushd "/usr/share/jeos-firstboot/modules" &>/dev/null; then
         popd &>/dev/null
 fi
 
+module_has_hook() {
+	local module="$1"
+	local module_func="$2"
+	module_function="${module}_${module_func}"
+	[ "$(type -t -- "${module_function}")" = "function" ]
+}
+
 call_module() {
 	local module="$1"
 	local module_func="$2"

--- a/files/usr/share/jeos-firstboot/modules/network
+++ b/files/usr/share/jeos-firstboot/modules/network
@@ -1,0 +1,76 @@
+# Copyright (c) 2022 SUSE LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+do_wicked_autoconfig()
+{
+	d --infobox $"Collecting network info ..." 3 33
+
+	shopt -s nullglob
+
+	for net_path in /sys/class/net/*; do
+		[ -d "$net_path" ] || continue # skip bonding_masters file
+
+		net_device=${net_path##*/}
+
+		[ "$net_device" = "lo" ] && continue
+
+		# Only devices having ID_NET_NAME.* attrs
+		# Ignore errors if udev not available
+		udevadm info -q property -p "$net_path" 2>/dev/null | grep -qs ID_NET_NAME || continue
+		# But don't touch WLAN interfaces
+		udevadm info -q property -p "$net_path" | grep -qs "DEVTYPE=wlan" && continue
+
+		unset IPADDR
+		eval `wicked test dhcp4 "$net_device" 2>/dev/null | grep -E "^IPADDR="`
+		ip link set down "$net_device" # set link down after probe once done
+
+		# Create a configuration file for each interface that provides
+		# an IPADDR
+		if [ -n "$IPADDR" ]; then
+			printf "STARTMODE=auto\nBOOTPROTO=dhcp\n" \
+				> "/etc/sysconfig/network/ifcfg-$net_device"
+		fi
+	done
+
+	run sed -i -E 's/^DHCLIENT(6?)_SET_HOSTNAME=.*$/DHCLIENT\1_SET_HOSTNAME=yes/' /etc/sysconfig/network/dhcp
+}
+
+network_jeos_config()
+{
+	if [ "$(current_network_service)" = "NetworkManager" ]; then
+		nmtui
+		exit 0
+	fi
+
+	if ! d --yesno $"This will create a new network configuration from scratch,
+all connections will be lost.\nDo you want to continue?" 7 50; then
+		return
+	fi
+	do_wicked_autoconfig
+	d --infobox $"Restarting network ..." 3 26 || true
+	systemctl restart network
+}
+
+network_systemd_firstboot()
+{
+	if [ "$(current_network_service)" != "NetworkManager" ]; then
+		do_wicked_autoconfig
+	fi
+}

--- a/files/usr/share/jeos-firstboot/modules/network-modules/NetworkManager
+++ b/files/usr/share/jeos-firstboot/modules/network-modules/NetworkManager
@@ -18,16 +18,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# Returns the basename of the target of network.service,
-# e.g. "wicked" or "NetworkManager"
-current_network_service()
+network_jeos_config()
 {
-	systemctl show -P Id network.service | cut -d. -f1
+	nmtui
 }
 
-network_service="$(current_network_service)"
-if [ -e "/usr/share/jeos-firstboot/modules/network-modules/${network_service}" ]; then
-	. "/usr/share/jeos-firstboot/modules/network-modules/${network_service}"
-else
-	echo "No network configuration module for ${network_service} found" >&2
-fi
+network_systemd_firstboot()
+{
+}

--- a/files/usr/share/jeos-firstboot/modules/network-modules/NetworkManager
+++ b/files/usr/share/jeos-firstboot/modules/network-modules/NetworkManager
@@ -25,4 +25,19 @@ network_jeos_config()
 
 network_systemd_firstboot()
 {
+	if [ "$(nmcli networking connectivity)" = "none" ]; then
+		welcome_screen_with_console_switch
+
+		# Note: Dialog also flushes the input queue here. Without that,
+		# nmtui would react to what is typed before it shows up.
+		if dialog --backtitle "$PRETTY_NAME" --yesno $"No active network connection detected.\nDo you want to configure network connections?" 0 0; then
+			# nmtui (resp. libslang used by newt) uses /dev/tty,
+			# so setsid is required to set it to the current one.
+			setsid -wc nmtui
+			# setsid steals our tty connection, reopen it
+			if [ "$console" != "$(tty)" ]; then
+				exec 0<>"$console" 1>&0
+			fi
+		fi
+	fi
 }

--- a/files/usr/share/jeos-firstboot/modules/network-modules/wicked
+++ b/files/usr/share/jeos-firstboot/modules/network-modules/wicked
@@ -54,7 +54,7 @@ do_wicked_autoconfig()
 
 network_jeos_config()
 {
-	if ! d --yesno $"This will create a new network configuration from scratch,
+	if ! dialog --backtitle "$PRETTY_NAME" --yesno $"This will create a new network configuration from scratch,
 all connections will be lost.\nDo you want to continue?" 7 50; then
 		return
 	fi

--- a/files/usr/share/jeos-firstboot/modules/network-modules/wicked
+++ b/files/usr/share/jeos-firstboot/modules/network-modules/wicked
@@ -1,0 +1,69 @@
+# Copyright (c) 2022 SUSE LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+do_wicked_autoconfig()
+{
+	d --infobox $"Collecting network info ..." 3 33
+
+	shopt -s nullglob
+
+	for net_path in /sys/class/net/*; do
+		[ -d "$net_path" ] || continue # skip bonding_masters file
+
+		net_device=${net_path##*/}
+
+		[ "$net_device" = "lo" ] && continue
+
+		# Only devices having ID_NET_NAME.* attrs
+		# Ignore errors if udev not available
+		udevadm info -q property -p "$net_path" 2>/dev/null | grep -qs ID_NET_NAME || continue
+		# But don't touch WLAN interfaces
+		udevadm info -q property -p "$net_path" | grep -qs "DEVTYPE=wlan" && continue
+
+		unset IPADDR
+		eval `wicked test dhcp4 "$net_device" 2>/dev/null | grep -E "^IPADDR="`
+		ip link set down "$net_device" # set link down after probe once done
+
+		# Create a configuration file for each interface that provides
+		# an IPADDR
+		if [ -n "$IPADDR" ]; then
+			printf "STARTMODE=auto\nBOOTPROTO=dhcp\n" \
+				> "/etc/sysconfig/network/ifcfg-$net_device"
+		fi
+	done
+
+	run sed -i -E 's/^DHCLIENT(6?)_SET_HOSTNAME=.*$/DHCLIENT\1_SET_HOSTNAME=yes/' /etc/sysconfig/network/dhcp
+}
+
+network_jeos_config()
+{
+	if ! d --yesno $"This will create a new network configuration from scratch,
+all connections will be lost.\nDo you want to continue?" 7 50; then
+		return
+	fi
+	do_wicked_autoconfig
+	d --infobox $"Restarting network ..." 3 26 || true
+	systemctl restart network
+}
+
+network_systemd_firstboot()
+{
+	do_wicked_autoconfig
+}


### PR DESCRIPTION
Add an abstraction for network configuration modules.

So far completely untested.

- [x] Test
- [ ] What to do with the `DHCLIENT_SET_HOSTNAME` setting? Make it module agnostic, wicked specific or remove it altogether?
- [x] `nmtui` doesn't work if the console got switched. Might need `setsid`, but hopefully not.