### PR TITLE
Quick'n'dirty NetworkManager support

### DIFF
--- a/files/usr/sbin/jeos-config
+++ b/files/usr/sbin/jeos-config
@@ -125,6 +125,11 @@ case "$subcommand" in
 		timedatectl set-timezone "$JEOS_TIMEZONE"
 		;;	
 	network)
+		if [ "$(current_network_service)" = "NetworkManager" ]; then
+			nmtui
+			exit 0
+		fi
+
 		if ! d --yesno $"This will create a new network configuration from scratch,
 all connections will be lost.\nDo you want to continue?" 7 50; then
 			exit 0

--- a/files/usr/sbin/jeos-firstboot
+++ b/files/usr/sbin/jeos-firstboot
@@ -216,7 +216,9 @@ security fixes." 0 0 || true
 fi
 
 ## Configure initial network settings
-dialog_network
+if [ "$(current_network_service)" != "NetworkManager" ]; then
+	dialog_network
+fi
 
 call_module_hook systemd_firstboot
 

--- a/files/usr/share/jeos-firstboot/jeos-firstboot-functions
+++ b/files/usr/share/jeos-firstboot/jeos-firstboot-functions
@@ -155,4 +155,11 @@ resolve_tty() {
         fi
 }
 
+# Returns the basename of the target of network.service,
+# e.g. "wicked" or "NetworkManager"
+current_network_service()
+{
+	systemctl show -P Id network.service | cut -d. -f1
+}
+
 # vim: syntax=sh


### PR DESCRIPTION
Don't run wicked specific code in jeos-firstboot and run "nmtui" in
jeos-config.

https://github.com/openSUSE/jeos-firstboot/pull/91 allows implementing that in a less ugly way.

- [x] Test
- [ ] What to do with the `DHCLIENT_SET_HOSTNAME` setting? Make it module agnostic, wicked specific or remove it altogether?