### PR TITLE
Fix size of the "No root password set" dialog

### DIFF
--- a/files/usr/share/jeos-firstboot/jeos-firstboot-dialogs
+++ b/files/usr/share/jeos-firstboot/jeos-firstboot-dialogs
@@ -75,7 +75,7 @@ dialog_password()
 		if [ -z "$password" ]; then
 			warn $"Warning: No root password set.
 
-You cannot log in that way. A debug shell will be started on tty9 just this time. Use it to e.g. import your ssh key." 0 0 || true
+You cannot log in that way. A debug shell will be started on tty9 just this time. Use it to e.g. import your ssh key." || true
 		run systemctl start debug-shell.service
 		fi
 		break

--- a/files/usr/share/jeos-firstboot/jeos-firstboot-functions
+++ b/files/usr/share/jeos-firstboot/jeos-firstboot-functions
@@ -76,7 +76,7 @@ d(){
 }
 
 warn(){
-	d --title $"Warning" --msgbox "$1" 6 40
+	d --title $"Warning" --msgbox "$1" 0 0
 }
 
 # Given the number of total item pairs, outputs the number of items to display at once


### PR DESCRIPTION
The warn function hardcoded the size and the values were too small for this
message, so the important part was cut off and only visible through scrolling.
Fix that by always using automatic size.

The other warning dialogs look a bit odd now (not quite wide enough), but it's readable and they should never show up anyway...