### PR TITLE
Deduplicate wifi list

### DIFF
--- a/files/usr/share/jeos-firstboot/modules/raspberrywifi
+++ b/files/usr/share/jeos-firstboot/modules/raspberrywifi
@@ -22,7 +22,7 @@ raspberrywifi_get_wlan_networks()
 	if [ -n "${line}" ]; then
 		list+=("SSID=${line}" "${line}")
 	fi
-	done < <(ip link set $wlan_device up && iwlist $wlan_device scan|grep ESSID|cut -d':' -f2|cut -d'"' -f2)
+	done < <(ip link set $wlan_device up && iwlist $wlan_device scan|grep ESSID|cut -d':' -f2|cut -d'"' -f2|sort -u)
         list+=("manual" "Enter SSID manually")
 	[ -n "${list[*]}" ]
 }


### PR DESCRIPTION
Don't show ESSIDs multiple times just because there are multiple APs transmitting this ESSID.
https://bugzilla.suse.com/show_bug.cgi?id=1197487

Please submit this change for 15sp4.