### PR TITLE
Rewrite license code

### DIFF
--- a/files/usr/sbin/jeos-firstboot
+++ b/files/usr/sbin/jeos-firstboot
@@ -159,11 +159,12 @@ if [ -z "$JEOS_EULA_ALREADY_AGREED" ]; then
 		done
 	fi
 
-	if [ ! -e "${EULA_FILE%/*}/no-acceptance-needed" ]; then
-		while ! dialog --backtitle "$PRETTY_NAME" --textbox "$EULA_FILE" $dh_text 85 --and-widget --yesno $"Do you agree with the terms of the license?" 0 0; do
-			d --msgbox $"Can not continue without agreement" 6 40
-		done
-	fi
+	while true; do
+		d --textbox "$EULA_FILE" $dh_text 85
+		[ -e "${EULA_FILE%/*}/no-acceptance-needed" ] && break
+		dialog --yesno $"Do you agree with the terms of the license?" 0 0 && break
+		dialog --msgbox $"Can not continue without agreement" 6 40 || :
+	done
 fi
 
 if [ -z "$JEOS_TIMEZONE" ]; then


### PR DESCRIPTION
Make it a more flexible yet easier to understand loop.
This fixes that the license wasn't shown at all on openSUSE.