### PR TITLE
Support /usr/lib/os-release (#102)

### DIFF
--- a/files/usr/sbin/jeos-config
+++ b/files/usr/sbin/jeos-config
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: Copyright 2015-2022 SUSE LLC
 
-. /etc/os-release
 . "/usr/share/jeos-firstboot/jeos-firstboot-functions"
 . "/usr/share/jeos-firstboot/jeos-firstboot-dialogs"
 

--- a/files/usr/sbin/jeos-firstboot
+++ b/files/usr/sbin/jeos-firstboot
@@ -6,7 +6,6 @@ set -e
 
 TEXTDOMAIN='jeos-firstboot'
 
-. /etc/os-release
 . "/usr/share/jeos-firstboot/jeos-firstboot-functions"
 . "/usr/share/jeos-firstboot/jeos-firstboot-dialogs"
 . "/usr/share/jeos-firstboot/welcome-screen"

--- a/files/usr/share/jeos-firstboot/jeos-firstboot-functions
+++ b/files/usr/share/jeos-firstboot/jeos-firstboot-functions
@@ -1,6 +1,12 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: Copyright 2015-2022 SUSE LLC
 
+if [ -e /etc/os-release ]; then
+	. /etc/os-release
+else
+	. /usr/lib/os-release
+fi
+
 stty_size() {
 	set -- `stty size`; LINES=$1; COLUMNS=$2
 	# stty size can return zero when not ready or


### PR DESCRIPTION
Move reading os-release to jeos-firstboot-function and use /usr/lib/os-release if /etc/os-release is not available.