### PR TITLE
Add KeyringMode=shared

### DIFF
--- a/files/usr/lib/systemd/system/jeos-firstboot.service
+++ b/files/usr/lib/systemd/system/jeos-firstboot.service
@@ -34,6 +34,8 @@ ExecStart=/usr/sbin/jeos-firstboot
 StandardOutput=tty
 StandardInput=tty
 #StandardError=tty
+# enable accessing global keyring to get data from eg. initrd
+KeyringMode=shared
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
In case the initrd puts keys in the kernel keyring, e.g. for disk encryption the firstboot wizard may want to access them.