### PR TITLE
status_mail: Rerun status-mail-generator after saving

### DIFF
--- a/files/usr/share/jeos-firstboot/modules/status_mail
+++ b/files/usr/share/jeos-firstboot/modules/status_mail
@@ -90,6 +90,9 @@ status_mail_do_config()
 		status_mail_set_config_option MAILX_OPTIONS "${input[5]}"
 	fi
 
+	# The config file impacts the generator, run it again.
+	systemctl daemon-reload
+
 	return 0
 }
 


### PR DESCRIPTION
Technically needed only after changing ADDRESS to or from empty, but do it unconditionally for predictable and consistent behaviour.