### PR TITLE
Only skip jeos-firstboot if cloud-init found a config source (bsc#1220281)

### DIFF
--- a/files/usr/lib/systemd/system/jeos-firstboot.service
+++ b/files/usr/lib/systemd/system/jeos-firstboot.service
@@ -18,9 +18,9 @@ Before=wicked.service systemd-user-sessions.service
 # For NM it uses nmcli, so NM needs to be running
 After=NetworkManager.service
 
-# The existence of this file reflects whether cloud-init's systemd-generator enables cloud-init.
-# If it does not exist, cloud-init won't run, so it's our turn.
-ConditionPathExists=!/run/cloud-init/enabled
+# If cloud-init is used on the system, wait until it's done to be able
+# to check whether it performed any configuration.
+After=cloud-config.target
 
 # jeos-firstboot-snapshot.service deletes the flag file, but starts after us
 Wants=jeos-firstboot-snapshot.service

--- a/files/usr/sbin/jeos-firstboot
+++ b/files/usr/sbin/jeos-firstboot
@@ -33,6 +33,11 @@ else
 	dry=1
 fi
 
+if [ -e /run/cloud-init/enabled ] && ! grep -qw none /run/cloud-init/cloud-id; then
+	echo $"System configured with cloud-init, skipping jeos-firstboot"
+	exit 0
+fi
+
 if [ -n "$dry" ]; then
 	run() {
 		echo "$@"


### PR DESCRIPTION
There are cases in which ds-identify enables cloud-init but there isn't actually a data source. Check for that by reading a file in /run. It's not possible to express that as unit condition, so do it in code.