### PR TITLE
Resolve cycle w.r.t. wicked

### DIFF
--- a/files/usr/lib/systemd/system/jeos-firstboot.service
+++ b/files/usr/lib/systemd/system/jeos-firstboot.service
@@ -20,7 +20,7 @@ After=NetworkManager.service
 
 # If cloud-init is used on the system, wait until it's done to be able
 # to check whether it performed any configuration.
-After=cloud-config.target
+After=cloud-init-local.service
 
 # jeos-firstboot-snapshot.service deletes the flag file, but starts after us
 Wants=jeos-firstboot-snapshot.service


### PR DESCRIPTION
cloud-init.target include cloud-init.service which needs to run after wicked. But this service wants to run prior to wicked. However, cloud-init knows what it shold be doing after the cloud-init-local phase and that service runs prior to wicked. As such the requirements from a systemd timing perspective are consistent.