### PR TITLE
Add modules for user creation and pam_oath configuration

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,0 @@
-This is a lightweight, dialog based firstboot wizard that replaces
-systemd's line based firstboot program. It can show the license and
-prompt for language, keyboard and root passsword.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,7 @@ It is a lightweight and customisable firstboot wizard that allows to set basic s
 
 This is mainly developed for openSUSE and SUSE Linux Enterprise Server JeOS images. For more information visit the [JeOS wiki](https://en.opensuse.org/Portal:JeOS).
 
-## Getting Started
-jeos-firstboot can be extended using separate modules, writing a script with the appropriate format and have it installed under `/usr/lib/share/jeos-firstboot/modules` or `/etc/jeos-firstboot/modules` will make this module be executed.
-For more information on modules format please check [jeos-firstboot extensions](https://en.opensuse.org/Portal:JeOS:Documentation)
-
-### Installation
+## Installation
 
 The RPM package is developed in openSUSE OBS [devel package](https://build.opensuse.org/package/show/devel:openSUSE:Factory/jeos-firstboot)
 
@@ -50,6 +46,38 @@ Configure system settings using an interactive dialog
 Additional modules (like raspberrywifi) are shown if present.
 
 If no parameter is given it shows a dialog for selection.
+
+## Writing modules
+
+jeos-firstboot can be extended using modules written in bash placed in `/usr/share/jeos-firstboot/modules/` or `/etc/jeos-firstboot/modules/`. Modules in `/etc/jeos-firstboot/modules/` will be preferred. If a link to `/dev/null` is encountered, the module is skipped.
+
+The basename of the module file is its name. It is used as prefix of properties and hooks. It is also used as argument to jeos-config when calling the module directly.
+
+### Properties
+
+```sh
+# Shown in jeos-config for module selection
+yourmodule_title="Title of your module"
+# Shown in jeos-config --help
+yourmodule_description="Show an awesome dialog with a nice button"
+# Priority of the module. Modules with higher priority are run later in jeos-firstboot and shown below in jeos-config.
+# The default is 50.
+yourmodule_priority=50
+```
+
+### Hooks
+
+```sh
+# Runs if called by jeos-firstboot, currently after systemd-firstboot is called
+# (that should probably be changed)
+yourmodule_systemd_firstboot() { }
+# Runs if called by jeos-firstboot, after all systemd_firstboot hooks.
+yourmodule_post() { }
+# Runs if called by jeos-config
+yourmodule_jeos_config() { }
+# Runs at the end of jeos-firstboot just before exiting.
+yourmodule_cleanup() { }
+```
 
 <!-- CONTRIBUTING -->
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ You can check the example in the RPM package for installation.
 The service is controlled by a file, so after installing it you should be sure that your system is configured appropriately
 
 ```sh
-        # Enable jeos-firstboot
-        mkdir -p /var/lib/YaST2
-        touch /var/lib/YaST2/reconfig_system
+# Enable jeos-firstboot
+mkdir -p /var/lib/YaST2
+touch /var/lib/YaST2/reconfig_system
 
-        systemctl mask systemd-firstboot.service
-        systemctl enable jeos-firstboot.service
+systemctl mask systemd-firstboot.service
+systemctl enable jeos-firstboot.service
 ```
 Beside the service that runs on firstboot there is also a tool to change configuration in a running system, this will also be installed and available as `jeos-config`
 
@@ -39,13 +39,13 @@ jeos-config usage:
 Usage: jeos-config [OPTION...] [CONFIG_NAME]
 Configure system settings using an interactive dialog
 
-        -h              shows this usage help
-        locale          Show configuration for locale
-        keytable        Show configuration for keyboard
-        timezone        Show configuration for timezone
-        password        Show configuration for password
-        network         Show configuration for network
-        raspberrywifi   Show configuration for raspberrywifi
+	-h              shows this usage help
+	locale          Show configuration for locale
+	keytable        Show configuration for keyboard
+	timezone        Show configuration for timezone
+	password        Show configuration for password
+	network         Show configuration for network
+	raspberrywifi   Show configuration for raspberrywifi
 ```     
 Additional modules (like raspberrywifi) are shown if present.
 

--- a/files/usr/sbin/jeos-config
+++ b/files/usr/sbin/jeos-config
@@ -83,7 +83,7 @@ while getopts ":h" opt; do
 		\?) 
 			echo "Invalid Option: -$OPTARG" 1>&2
 			usage
-     			exit 1
+			exit 1
 			;;
 	esac
 done
@@ -98,15 +98,15 @@ fi
 case "$subcommand" in
 	locale)
 		list=() # Set by findlocales
-        	if ! findlocales; then
-                	d --msgbox $"No locales found" 0 0
-        	elif [ "${#list[@]}" -eq 2 ]; then # Only a single entry
+		if ! findlocales; then
+			d --msgbox $"No locales found" 0 0
+		elif [ "${#list[@]}" -eq 2 ]; then # Only a single entry
 			d --msgbox $"Locale set to ${list[0]}, no more locales available" 5 50
 		else
 			dialog_locale
 			apply_locale
 		fi
-        	;;
+		;;
 	keytable)
 		dialog_keytable
 		JEOS_LOCALE="$(get_current_locale)"

--- a/files/usr/sbin/jeos-config
+++ b/files/usr/sbin/jeos-config
@@ -49,12 +49,12 @@ done
 
 select_config()
 {
-	modules_order=("locale" '' "keytable" '' "timezone" '' "password" '')
+	local modules_order=("locale" $"Locale" "keytable" $"Keyboard Layout" "timezone" $"Timezone" "password" $"Password")
 	for module in "${config_modules[@]}"; do
-		modules_order+=("${module}" '')
+		modules_order+=("$module" "$(module_get_prop "${module}" "title" "${module}")")
 	done
 
-	d_with_result --menu $"Select configuration module" 0 0 "$(menuheight ${#modules_order[@]})" "${modules_order[@]}" || exit 0
+	d_with_result --no-tags --menu $"Select configuration module" 0 0 "$(menuheight ${#modules_order[@]})" "${modules_order[@]}" || exit 0
 }
 
 usage()
@@ -68,10 +68,11 @@ Configure system settings using an interactive dialog
 	keytable	Show configuration for keyboard
 	timezone	Show configuration for timezone
 	password	Show configuration for password
-$(for module in "${config_modules[@]}"; do
-	echo "	${module}	Show configuration for ${module}"
-done)
 EOF
+	for module in "${config_modules[@]}"; do
+		local fallbackdescription="$(printf $"Show configuration for %s" "${module}")"
+		printf "\t%-8s\t%s\n" "${module}" "$(module_get_prop "$module" "description" "$fallbackdescription")"
+	done
 }
 
 while getopts ":h" opt; do

--- a/files/usr/sbin/jeos-firstboot
+++ b/files/usr/sbin/jeos-firstboot
@@ -88,13 +88,13 @@ JEOS_KEYTABLE=${JEOS_KEYTABLE-}
 use_utc_as_default_tz=0
 
 if [ -z "$JEOS_LOCALE" ] && ! get_credential JEOS_LOCALE firstboot.locale; then
-    welcome_screen_with_console_switch
-    dialog_locale
+	welcome_screen_with_console_switch
+	dialog_locale
 
-    # Same check as inside dialog_locale
-    if [ "${#list[@]}" -eq 2 ]; then
-        use_utc_as_default_tz=1
-    fi
+	# Same check as inside dialog_locale
+	if [ "${#list[@]}" -eq 2 ]; then
+		use_utc_as_default_tz=1
+	fi
 fi
 
 # Activate the locale selected
@@ -103,8 +103,8 @@ apply_locale
 systemd_firstboot_args+=("--locale=$JEOS_LOCALE")
 
 if [ -z "$JEOS_KEYTABLE" ] && ! get_credential JEOS_KEYTABLE firstboot.keymap; then
-    welcome_screen_with_console_switch
-    dialog_keytable
+	welcome_screen_with_console_switch
+	dialog_keytable
 fi 
 
 # langset.sh needs locale to set keytable
@@ -121,20 +121,20 @@ force_english_license=0
 export LANG="$JEOS_LOCALE"
 
 kmscon_available() {
-        # kmscon itself is installed
-        kmscon --help >/dev/null 2>&1 || return 1
-        # At least one monospace font is available
-        [ -n "$(fc-match "monospace" 2>/dev/null)" ] || return 1
+	# kmscon itself is installed
+	kmscon --help >/dev/null 2>&1 || return 1
+	# At least one monospace font is available
+	[ -n "$(fc-match "monospace" 2>/dev/null)" ] || return 1
 
-        return 0
+	return 0
 }
 
 fbiterm_available() {
-        # fbiterm itself is installed
-        fbiterm --help >/dev/null 2>&1 || return 1
-        # fbiterm comes with its own fallback font
+	# fbiterm itself is installed
+	fbiterm --help >/dev/null 2>&1 || return 1
+	# fbiterm comes with its own fallback font
 
-        return 0
+	return 0
 }
 
 if [[ "$(resolve_tty "$(tty)")" =~ /dev/tty[0-9]+ ]]; then
@@ -196,8 +196,8 @@ if [ -z "$JEOS_EULA_ALREADY_AGREED" ] && ! get_credential JEOS_EULA_ALREADY_AGRE
 fi
 
 if [ -z "$JEOS_TIMEZONE" ] && ! get_credential JEOS_TIMEZONE firstboot.timezone; then
-    welcome_screen_with_console_switch
-    dialog_timezone
+	welcome_screen_with_console_switch
+	dialog_timezone
 fi
 
 systemd_firstboot_args+=("--timezone=$JEOS_TIMEZONE")
@@ -207,8 +207,8 @@ run rm -f /etc/localtime
 run systemd-firstboot "${systemd_firstboot_args[@]}"
 
 if [ -z "$JEOS_PASSWORD_ALREADY_SET" ] && ! get_credential password passwd.plaintext-password.root; then
-    welcome_screen_with_console_switch
-    dialog_password
+	welcome_screen_with_console_switch
+	dialog_password
 fi
 
 # Only show the registration prompt on commercial distros and if it's not

--- a/files/usr/sbin/jeos-firstboot-snapshot
+++ b/files/usr/sbin/jeos-firstboot-snapshot
@@ -5,21 +5,21 @@
 set -euo pipefail
 
 if ! mountpoint -q /.snapshots &>/dev/null; then
-    echo "Snapshots not enabled, skipping"
-    exit 0
+	echo "Snapshots not enabled, skipping"
+	exit 0
 fi
 
 if mountpoint -q /etc; then
-    echo "/etc is not part of the snapshot, skipping"
-    exit 0
+	echo "/etc is not part of the snapshot, skipping"
+	exit 0
 fi
 
 if [ ! -e /.snapshots/2 ]; then
-    snapper -v create -d "After jeos-firstboot configuration" --userdata "important=yes"
+	snapper -v create -d "After jeos-firstboot configuration" --userdata "important=yes"
 fi
 
 if [ -x /usr/lib/snapper/plugins/grub ]; then
-    /usr/lib/snapper/plugins/grub --refresh
+	/usr/lib/snapper/plugins/grub --refresh
 fi
 
 exit 0

--- a/files/usr/share/jeos-firstboot/jeos-firstboot-dialogs
+++ b/files/usr/share/jeos-firstboot/jeos-firstboot-dialogs
@@ -14,38 +14,38 @@ menulist()
 
 dialog_locale()
 {
-        default="en_US"
-        [ -f /etc/locale.conf ] && locale_lang="$(awk -F= '$1 == "LANG" { split($2,fs,"."); print fs[1]; exit }' /etc/locale.conf)"
-        [ -n "$locale_lang" ] && default="$locale_lang"
+	default="en_US"
+	[ -f /etc/locale.conf ] && locale_lang="$(awk -F= '$1 == "LANG" { split($2,fs,"."); print fs[1]; exit }' /etc/locale.conf)"
+	[ -n "$locale_lang" ] && default="$locale_lang"
 
-        list=() # Set by findlocales
-        newlocale="$default"
-        if ! findlocales; then
-                d --msgbox $"No locales found" 0 0
-        elif [ "${#list[@]}" -eq 2 ]; then # Only a single entry
-                newlocale="${list[0]}"
-        else
-                d --default-item "$default" --menu $"Select system locale" 0 0 "$(menuheight ${#list[@]})" "${list[@]}"
-                newlocale="${result}"
-        fi
+	list=() # Set by findlocales
+	newlocale="$default"
+	if ! findlocales; then
+		d --msgbox $"No locales found" 0 0
+	elif [ "${#list[@]}" -eq 2 ]; then # Only a single entry
+		newlocale="${list[0]}"
+	else
+		d --default-item "$default" --menu $"Select system locale" 0 0 "$(menuheight ${#list[@]})" "${list[@]}"
+		newlocale="${result}"
+	fi
 
-        JEOS_LOCALE="${newlocale}.UTF-8"
+	JEOS_LOCALE="${newlocale}.UTF-8"
 }
 
 dialog_keytable()
 {
-        default="us"
-        [ -f /etc/vconsole.conf ] && vconsole_keymap="$(awk -F= '$1 == "KEYMAP" { split($2,fs,"."); print fs[1]; exit }' /etc/vconsole.conf)"
-        [ -n "$vconsole_keymap" ] && default="$vconsole_keymap"
+	default="us"
+	[ -f /etc/vconsole.conf ] && vconsole_keymap="$(awk -F= '$1 == "KEYMAP" { split($2,fs,"."); print fs[1]; exit }' /etc/vconsole.conf)"
+	[ -n "$vconsole_keymap" ] && default="$vconsole_keymap"
 
-        if findkeymaps \
-                && d --default-item "$default" --menu  $"Select keyboard layout" 0 0 "$(menuheight ${#list[@]})" "${list[@]}"; then
-                if [ -n "$result" ]; then
-                        JEOS_KEYTABLE="$result"
-                fi
-        else
-                d --msgbox $"Error setting keyboard" 5 26
-        fi
+	if findkeymaps \
+		&& d --default-item "$default" --menu  $"Select keyboard layout" 0 0 "$(menuheight ${#list[@]})" "${list[@]}"; then
+		if [ -n "$result" ]; then
+			JEOS_KEYTABLE="$result"
+		fi
+	else
+		d --msgbox $"Error setting keyboard" 5 26
+	fi
 }
 
 dialog_timezone()

--- a/files/usr/share/jeos-firstboot/jeos-firstboot-functions
+++ b/files/usr/share/jeos-firstboot/jeos-firstboot-functions
@@ -22,6 +22,9 @@ stty_size() {
 }
 stty_size
 
+# Make sure globs and regex are consistent everywhere.
+LC_COLLATE=C.UTF-8
+
 result=
 list=
 password=''

--- a/files/usr/share/jeos-firstboot/jeos-firstboot-functions
+++ b/files/usr/share/jeos-firstboot/jeos-firstboot-functions
@@ -36,17 +36,35 @@ _find_modules() {
 	done
 }
 
+# Echos the value of the module variable or a fallback if unset.
+# Usage: module_get_prop modulename varname defaultvalue
+module_get_prop() {
+	local module="$1"
+	local varname="$2"
+	local default="${3-}"
+	local fullname="${module}_${varname}"
+	echo -n "${!fullname-"${default}"}"
+}
+
 init_modules() {
 	[ -z "$modules" ] || return 0
-	local module f
+	local module f _prio
+	local unordered_modules=()
 	while read -r module f; do
 		if [ -L "$f" ] && [ "$(readlink "$f")" = "/dev/null" ]; then
 			continue
 		fi
 		# shellcheck source=/dev/null
 		source "$f" || continue
-		modules+=("${module}")
+		unordered_modules+=("${module}")
 	done < <(_find_modules|sort -k 1,1 -u)
+
+	# Sort modules by priority
+	while read -r _prio module; do
+		modules+=("${module}")
+	done < <(for module in "${unordered_modules[@]}"; do
+			module_get_prop "$module" "priority" 50; echo " $module"
+		done | sort -n)
 }
 
 module_has_hook() {

--- a/files/usr/share/jeos-firstboot/jeos-firstboot-functions
+++ b/files/usr/share/jeos-firstboot/jeos-firstboot-functions
@@ -28,13 +28,11 @@ password=''
 modules=()
 
 _find_modules() {
-	local d f
-	for d in "/etc/jeos-firstboot/modules" "${jeos_prefix?}/share/jeos-firstboot/modules"; do
-		for f in "$d"/*; do
-			if [ -L "$f" ] || [ -f "$f" ]; then
-				echo "${f##*/}" "$f"
-			fi
-		done
+	local f
+	for f in /etc/jeos-firstboot/modules/* "${jeos_prefix?}/share/jeos-firstboot/modules"/*; do
+		if [ -L "$f" ] || [ -f "$f" ]; then
+			echo "${f##*/}" "$f"
+		fi
 	done
 }
 

--- a/files/usr/share/jeos-firstboot/jeos-firstboot-functions
+++ b/files/usr/share/jeos-firstboot/jeos-firstboot-functions
@@ -69,11 +69,11 @@ call_module() {
 }
 
 call_module_hook() {
-        local hook="$1"
-        for module in "${modules[@]}"; do
+	local hook="$1"
+	for module in "${modules[@]}"; do
 		call_module "${module}" "${hook}" || continue
-        done
-        return 0
+	done
+	return 0
 }
 
 # Run dialog with jeos-firstboot style options applied
@@ -132,25 +132,25 @@ menuheight() {
 # by YaST/langset.sh, so we need to show them.
 findkeymaps()
 {
-        list=()
-        local line
-        while read line; do
-                list+=("${line%.map.gz}" '')
-        done < <(find /usr/share/kbd/keymaps -name '*.map.gz' -printf "%f\n" | sort -u)
-        [ -n "$list" ]
+	list=()
+	local line
+	while read line; do
+		list+=("${line%.map.gz}" '')
+	done < <(find /usr/share/kbd/keymaps -name '*.map.gz' -printf "%f\n" | sort -u)
+	[ -n "$list" ]
 }
 
 findlocales()
 {
-        list=()
-        local l locale
-        # List only locales which are both in live-langset-data and glibc-locale(-base)
-        for l in /usr/share/langset/*; do
-                locale="${l#/usr/share/langset/}"
-                [ -d "/usr/lib/locale/${locale}.utf8" ] || continue
-                list+=("${locale}" '')
-        done
-        [ -n "$list" ]
+	list=()
+	local l locale
+	# List only locales which are both in live-langset-data and glibc-locale(-base)
+	for l in /usr/share/langset/*; do
+		locale="${l#/usr/share/langset/}"
+		[ -d "/usr/lib/locale/${locale}.utf8" ] || continue
+		list+=("${locale}" '')
+	done
+	[ -n "$list" ]
 }
 
 get_current_locale()
@@ -185,16 +185,16 @@ apply_password()
 
 # Resolves /dev/console and /dev/tty0
 resolve_tty() {
-        local tty="$1"
-        if [ "$tty" = "/dev/console" ]; then
-                tty=$(awk '{printf "/dev/%s", $NF}' /sys/class/tty/console/active)
-        fi
+	local tty="$1"
+	if [ "$tty" = "/dev/console" ]; then
+		tty=$(awk '{printf "/dev/%s", $NF}' /sys/class/tty/console/active)
+	fi
 
-        if [ "$tty" = "/dev/tty0" ]; then
-                printf "/dev/%s" "$(cat /sys/class/tty/tty0/active)"
-        else
-                echo -n "$tty"
-        fi
+	if [ "$tty" = "/dev/tty0" ]; then
+		printf "/dev/%s" "$(cat /sys/class/tty/tty0/active)"
+	else
+		echo -n "$tty"
+	fi
 }
 
 # get systemd credential

--- a/files/usr/share/jeos-firstboot/modules/otp
+++ b/files/usr/share/jeos-firstboot/modules/otp
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: Copyright 2024 SUSE LLC
+# shellcheck shell=bash
+
+otp_title=$"TOTP for Cockpit Login"
+otp_description=$"Set up TOTP for cockpit user authentication"
+otp_priority=70
+
+_otp_do_config_for_user()
+{
+	local user="$1"
+
+	# Generate secret in base32 (most common format). Length 32 -> 160 bits -> 20 bytes.
+	local totp_secret
+	if ! totp_secret="$(LC_ALL=C tr -dc "A-Z2-7" </dev/urandom | head -c 32)"; then
+		d_styled --title "$otp_title" --msgbox $"Failed to generate TOTP secret" 6 45 || :
+		return 1
+	fi
+
+	# oath-toolkit prefers to work with the hex format.
+	local totp_secret_hex
+	totp_secret_hex="$(base32 -d <<<"$totp_secret" | hexdump -ve '1/1 "%.2x"')"
+
+	local url="otpauth://totp/${user}@$(hostname)?secret=${totp_secret}"
+	local msg="$(
+		printf $"Configuring time-based one-time password (TOTP) authentication for the user '%s'.\n\n" "$user"
+		printf $"Enroll with your desired TOTP application by scanning the QR code or entering the secret manually, then enter the generated 6 digit code below to confirm successful enrollment. "
+		printf $"Once confirmed, the Cockpit Web UI will ask for an OTP value on each login.\n\n"
+		printf $"TOTP Secret: %s\n\n" "${totp_secret}"
+		qrencode -t UTF8i -m 1 <<<"$url"
+	)"
+
+	while true; do
+		d_with_result --title "$otp_title" \
+			--cancel-label $"Skip" \
+			--no-nl-expand --no-collapse \
+			--mixedform "${msg}" 35 60 1 \
+			$"OTP value:" 1 0 "" 1 15 45 0 0
+
+		local ret=$?
+		if [ "$ret" -eq 1 ]; then
+			# Skip button pressed
+			return 0
+		elif [ "$ret" -eq 255 ]; then
+			# ESC
+			if d_styled --yesno $"Do you really want to quit?" 0 0; then
+				exit 1
+			fi
+			continue
+		fi
+
+		readarray -t input <<<"$result"
+		if ! echo "${totp_secret_hex}" | oathtool --totp -d 6 -w 3 - "${input[0]}" >/dev/null; then
+			d_styled --title "$otp_title" --msgbox $"TOTP did not match" 6 45 || :
+			continue
+		fi
+
+		# Replace or create token in ~/.pam_oath.
+		# Use su to run as the target user (not root) if necessary.
+		local run_as_user=("su" "$user" "-c")
+		if [ "$(whoami)" = "${user}" ]; then
+			run_as_user=("sh" "-e" "-c")
+		fi
+		# Iterate all lines, find the matching entry to modify or append a new one.
+		# FIXME: Use file used by the PAM configuration?
+		if "${run_as_user[@]}" "set -e; umask 077; touch ~/.pam_oath_usersfile; awk -i inplace -f - ~/.pam_oath_usersfile" <<EOF; then
+			\$2 == "${user}" { \$1 = "HOTP/T30/6"; \$4="${totp_secret_hex}"; replaced=1 }
+			1 { print }
+			ENDFILE { if (!replaced) { print "HOTP/T30/6 ${user} - ${totp_secret_hex}" } }
+EOF
+			break
+		fi
+
+		d_styled --title "$otp_title" --msgbox $"Failed to configure pam_oath" 6 45 || :
+		continue
+	done
+}
+
+# There might be multiple user accounts, ask if necessary.
+# Accepts an option --msg-if-no-users to show a dialog if no users found.
+_otp_do_config()
+{
+	# If not root, only allow configuration for the calling user
+	if [ "$(id -u)" != "0" ]; then
+		_otp_do_config_for_user "$(whoami)"
+		return
+	fi
+
+	# Otherwise allow configuring it for all users
+	local users
+	# Technically this should read login.defs for the UID range but that's not trivial.
+	readarray -t users < <(getent passwd | awk -F: '$3 >= 1000 && $3 <= 60000 { print $1; print $5; }')
+
+	if [ "${#users[@]}" -eq 0 ]; then
+		# No user to configure found
+		if [ "${1-}" = "--msg-if-no-users" ]; then
+			d_styled --title "$otp_title" --msgbox $"No users for TOTP configuration found" 6 45 || :
+		fi
+		return 0
+	elif [ "${#users[@]}" -eq 2 ]; then
+		_otp_do_config_for_user "${users[0]}"
+	else
+		while true; do
+			d_with_result --title "$otp_title" \
+				--cancel-label $"Skip" \
+				--menu $"Select user to configure" 0 0 "$(menuheight ${#users[@]})" "${users[@]}"
+
+			local ret=$?
+			if [ "$ret" -eq 1 ]; then
+				# Skip button pressed
+				return 0
+			elif [ "$ret" -eq 255 ]; then
+				# ESC
+				if d_styled --yesno $"Do you really want to quit?" 0 0; then
+					exit 1
+				fi
+				continue
+			fi
+
+			_otp_do_config_for_user "$result"
+		done
+	fi
+}
+
+# Only show the configuration if necessary packages are installed.
+if command -v oathtool >/dev/null && command -v qrencode >/dev/null; then
+	otp_systemd_firstboot()
+	{
+		_otp_do_config
+	}
+
+	otp_jeos_config()
+	{
+		_otp_do_config --msg-if-no-users
+	}
+fi

--- a/files/usr/share/jeos-firstboot/modules/raspberrywifi
+++ b/files/usr/share/jeos-firstboot/modules/raspberrywifi
@@ -20,11 +20,11 @@ raspberrywifi_get_wlan_networks()
 	list=()
 	local line
 	while read line; do
-	if [ -n "${line}" ]; then
-		list+=("SSID=${line}" "${line}")
-	fi
+		if [ -n "${line}" ]; then
+			list+=("SSID=${line}" "${line}")
+		fi
 	done < <(ip link set "$wlan_device" up && iwlist "$wlan_device" scan|grep ESSID|cut -d':' -f2|cut -d'"' -f2|sort -u)
-        list+=("manual" "Enter SSID manually")
+	list+=("manual" "Enter SSID manually")
 	[ -n "${list[*]}" ]
 }
 
@@ -43,62 +43,62 @@ is_raspberry()
 # jeos-firstboot modules extension.
 raspberrywifi_jeos_config()
 {
-while true
-do
-    if ! raspberrywifi_get_wlan_devices; then
-        if raspberrywifi_wlan_error $"Error listing wlan devices"; then
-            continue
-        fi
-        break
-    fi
+	while true
+	do
+		if ! raspberrywifi_get_wlan_devices; then
+			if raspberrywifi_wlan_error $"Error listing wlan devices"; then
+				continue
+			fi
+			break
+		fi
 
-    if [ "${#list[@]}" -eq "2" ]; then
-        wlan_device="${list[0]}"
-    else
-        d --menu  $"Select wireless card to configure" 0 0 "$(menuheight ${#list[@]})" "${list[@]}"
-        wlan_device="${result}"
-    fi
+		if [ "${#list[@]}" -eq "2" ]; then
+			wlan_device="${list[0]}"
+		else
+			d --menu  $"Select wireless card to configure" 0 0 "$(menuheight ${#list[@]})" "${list[@]}"
+			wlan_device="${result}"
+		fi
 
-    if raspberrywifi_get_wlan_networks; then
-        d --no-tags --menu $"Select wireless network to connect" 0 0 "$(menuheight ${#list[@]})" "${list[@]}"
-        wlan_network="$result"
-    else
-        if raspberrywifi_wlan_error $"Error listing wireless networks"; then
-            continue
-        fi
-        break
-    fi
-	if [ "$wlan_network" == "manual" ]; then
-		d --inputbox $"SSID of hidden network" 0 0
-		wlan_network="$result"
-	else
-		wlan_network="$(cut -d "=" -f2- <<< "$wlan_network")"
-	fi
-    list=($"WPA-PSK" '' $"WPA-EAP" '' $"Open" '')
-    d --menu $"Select authentication mode" 0 0 "$(menuheight ${#list[@]})" "${list[@]}"
-    wlan_auth_mode="$result"
+		if raspberrywifi_get_wlan_networks; then
+			d --no-tags --menu $"Select wireless network to connect" 0 0 "$(menuheight ${#list[@]})" "${list[@]}"
+			wlan_network="$result"
+		else
+			if raspberrywifi_wlan_error $"Error listing wireless networks"; then
+				continue
+			fi
+			break
+		fi
+		if [ "$wlan_network" == "manual" ]; then
+			d --inputbox $"SSID of hidden network" 0 0
+			wlan_network="$result"
+		else
+			wlan_network="$(cut -d "=" -f2- <<< "$wlan_network")"
+		fi
+		list=($"WPA-PSK" '' $"WPA-EAP" '' $"Open" '')
+		d --menu $"Select authentication mode" 0 0 "$(menuheight ${#list[@]})" "${list[@]}"
+		wlan_auth_mode="$result"
 
-    wlan_auth_mode_conf=
-    if [ "$wlan_auth_mode" = "WPA-EAP" ]; then
-        wlan_auth_mode_conf=eap
-        d --inputbox $"Username" 0 0
-        wlan_username="$result"
-    fi
-    if [ "$wlan_auth_mode" = "WPA-PSK" ]; then
-        wlan_auth_mode_conf=psk
-    fi
-    if [ "$wlan_auth_mode" = "Open" ]; then
-        wlan_auth_mode_conf=open
-    fi
-    if [ "$wlan_auth_mode" != "Open" ]; then
-        wlan_password=
-        d --insecure --passwordbox  $"Network password" 0 0
-        wlan_password="$result"
-    fi
+		wlan_auth_mode_conf=
+		if [ "$wlan_auth_mode" = "WPA-EAP" ]; then
+			wlan_auth_mode_conf=eap
+			d --inputbox $"Username" 0 0
+			wlan_username="$result"
+		fi
+		if [ "$wlan_auth_mode" = "WPA-PSK" ]; then
+			wlan_auth_mode_conf=psk
+		fi
+		if [ "$wlan_auth_mode" = "Open" ]; then
+			wlan_auth_mode_conf=open
+		fi
+		if [ "$wlan_auth_mode" != "Open" ]; then
+			wlan_password=
+			d --insecure --passwordbox $"Network password" 0 0
+			wlan_password="$result"
+		fi
 
-    config_file=$(mktemp -qt 'firstboot-XXXXXX')
+		config_file=$(mktemp -qt 'firstboot-XXXXXX')
 
-    cat << EOF > "$config_file"
+		cat << EOF > "$config_file"
 BOOTPROTO='dhcp'
 STARTMODE='auto'
 WIRELESS_AP_SCANMODE='1'
@@ -106,27 +106,27 @@ WIRELESS_AUTH_MODE='$wlan_auth_mode_conf'
 WIRELESS_ESSID='$wlan_network'
 WIRELESS_MODE='Managed'
 EOF
-    if [ "$wlan_auth_mode" = "WPA-PSK" ]; then
-        echo "WIRELESS_WPA_PSK='$wlan_password'" >> "$config_file"
-    fi
+		if [ "$wlan_auth_mode" = "WPA-PSK" ]; then
+			echo "WIRELESS_WPA_PSK='$wlan_password'" >> "$config_file"
+		fi
 
-    if [ "$wlan_auth_mode" = "WPA-EAP" ]; then
-        echo "WIRELESS_WPA_IDENTITY='$wlan_username'" >> "$config_file"
-        echo "WIRELESS_WPA_PASSWORD='$wlan_password'" >> "$config_file"
-        echo "WIRELESS_EAP_AUTH='mschapv2'" >> "$config_file"
-    fi
+		if [ "$wlan_auth_mode" = "WPA-EAP" ]; then
+			echo "WIRELESS_WPA_IDENTITY='$wlan_username'" >> "$config_file"
+			echo "WIRELESS_WPA_PASSWORD='$wlan_password'" >> "$config_file"
+			echo "WIRELESS_EAP_AUTH='mschapv2'" >> "$config_file"
+		fi
 
-    run mv -f "$config_file" /etc/sysconfig/network/ifcfg-"$wlan_device"
-    d --infobox $"Connecting to wireless network ..." 3 38 || true
+		run mv -f "$config_file" /etc/sysconfig/network/ifcfg-"$wlan_device"
+		d --infobox $"Connecting to wireless network ..." 3 38 || true
 
-    run ifdown "$wlan_device" &>/dev/null || true
-    if ! run ifup "$wlan_device" &>/dev/null; then
-        if dialog --backtitle "$PRETTY_NAME" --yesno $"Connection failed, do you wish to retry?" 0 0; then
-            continue
-        fi
-    fi
-    return 0
-done
+		run ifdown "$wlan_device" &>/dev/null || true
+		if ! run ifup "$wlan_device" &>/dev/null; then
+			if dialog --backtitle "$PRETTY_NAME" --yesno $"Connection failed, do you wish to retry?" 0 0; then
+				continue
+			fi
+		fi
+		return 0
+	done
 }
 
 # This is called by jeos-firstboot for user

--- a/files/usr/share/jeos-firstboot/modules/user
+++ b/files/usr/share/jeos-firstboot/modules/user
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: Copyright 2024 SUSE LLC
+# shellcheck shell=bash
+
+user_title=$"User Creation"
+user_description=$"Create an unprivileged user account"
+user_priority=60
+
+user_do_config()
+{
+	local username=""
+	local fullname=""
+	local errmsg
+
+	# Loop until cancelled or successfully completed.
+	while true; do
+		local msg="$(
+			echo $"If desired, create an additional user account."
+			echo $"This is necessary for password-based SSH login and the Cockpit Web UI."
+		)"
+
+		d_with_result --title $"User Creation" \
+			--insecure \
+			--cancel-label $"Skip" \
+			--mixedform "${msg}" 9 0 5 \
+			$"Username" 1 0 "$username" 1 18 35 0 0 \
+			$"Full name" 2 0 "$fullname" 2 18 35 0 0 \
+			$"Password" 4 0 "" 4 18 35 0 1 \
+			$"Password (again)" 5 0 "" 5 18 35 0 1
+
+		local ret=$?
+		if [ "$ret" -eq 1 ]; then
+			# Skip button pressed
+			return 0
+		elif [ "$ret" -eq 255 ]; then
+			# ESC
+			if d_styled --yesno $"Do you really want to quit?" 0 0; then
+				exit 1
+			fi
+			continue
+		fi
+
+		readarray -t input <<<"$result"
+
+		# Collect input
+		username="${input[0]}"
+		fullname="${input[1]}"
+		# Make sure not to pass those as parameters to processes!
+		local password="${input[2]}"
+		local password_repeat="${input[3]}"
+
+		# Input handling and validation
+		if ! [[ "$username" =~ ^[a-z][-_a-z0-9]*$ ]]; then
+			d_styled --title $"User Creation" --msgbox $"Invalid username.\nMake sure it starts with a 
+				lowercase letter and only contains -, _, digits and lowercase letters." 8 45
+			continue
+		fi
+
+		if [ -z "$password" ]; then
+			d_styled --title $"User Creation" --msgbox $"You have to enter a password" 8 45
+			continue
+		fi
+
+		if [ "$password" != "$password_repeat" ]; then
+			d_styled --title $"User Creation" --msgbox $"Passwords do not match." 8 45
+			continue
+		fi
+
+		# Password strength check
+		errmsg="$(printf "%s" "$password" | cracklib-check 2>&1)"
+		# For some reason cracklib-check includes the password in the message.
+		# https://github.com/cracklib/cracklib/pull/78 improves this, but it's too new.
+		errmsg="${errmsg/*: /}"
+		if [ "$errmsg" != "OK" ]; then
+			d_styled --title $"User Creation" --msgbox "$(printf $"cracklib-check failed: %s" "$errmsg")" 8 45
+			continue
+		fi
+
+		errmsg="$(useradd "$username" -c "$fullname" 2>&1)"
+		if [ "$?" -ne 0 ]; then
+			d_styled --title $"User Creation" --msgbox "$(printf $"useradd failed: %s" "$errmsg")" 8 45
+			continue
+		fi
+
+		# Set the requested password
+		if ! printf "%s:%s" "$username" "$password" | chpasswd; then
+			d_styled --title $"User Creation" --msgbox "$(printf $"chpasswd failed, leaving account locked: %s" "$errmsg")" 8 45
+			# Nothing we can do here, admin can fix this locally as root
+		fi
+
+		break
+	done
+
+	return 0
+}
+
+user_systemd_firstboot()
+{
+	user_do_config
+}
+
+user_jeos_config()
+{
+	user_do_config
+}


### PR DESCRIPTION
Do some necessary cleanups + add some API for more flexibility with modules.

Add a basic module for user account creation:

![Bildschirmfoto_20240807_165837](https://github.com/user-attachments/assets/9efc234f-091c-4f9e-a682-cfaca4bd3467)

Add a module for `pam_oath` configuration. It puts the configuration into the target user's `~/.pam_oath_usersfile`:

![Bildschirmfoto_20240807_170001](https://github.com/user-attachments/assets/807216ba-5a98-4755-bb08-e1da55c158ae)