### PR TITLE
OTP module improvements

### DIFF
--- a/files/usr/share/jeos-firstboot/modules/otp
+++ b/files/usr/share/jeos-firstboot/modules/otp
@@ -23,7 +23,7 @@ _otp_do_config_for_user()
 	local totp_secret_hex
 	totp_secret_hex="$(base32 -d <<<"$totp_secret" | hexdump -ve '1/1 "%.2x"')"
 
-	local url="otpauth://totp/${user}@$(hostname)?secret=${totp_secret}"
+	local url="otpauth://totp/${user}?secret=${totp_secret}&issuer=$(uname -n)"
 	local msg="$(
 		printf $"Configuring time-based one-time password (TOTP) authentication for the user '%s'.\n\n" "$user"
 		printf $"Enroll with your desired TOTP application by scanning the QR code or entering the secret manually, then enter the generated 6 digit code below to confirm successful enrollment. "
@@ -36,7 +36,7 @@ _otp_do_config_for_user()
 		d_with_result --title "$otp_title" \
 			--cancel-label $"Skip" \
 			--no-nl-expand --no-collapse \
-			--mixedform "${msg}" 35 60 1 \
+			--mixedform "${msg}" 37 60 1 \
 			$"OTP value:" 1 0 "" 1 15 45 0 0
 
 		local ret=$?

--- a/files/usr/share/jeos-firstboot/modules/otp
+++ b/files/usr/share/jeos-firstboot/modules/otp
@@ -10,9 +10,11 @@ _otp_do_config_for_user()
 {
 	local user="$1"
 
-	# Generate secret in base32 (most common format). Length 32 -> 160 bits -> 20 bytes.
+	# Generate secret in base32 (most common format).
+	# 20 bytes (-> 160 bits) result in 32 base32 characters (5 bits each) and
+	# 40 hex digits (4 bits each), so no padding is necessary.
 	local totp_secret
-	if ! totp_secret="$(LC_ALL=C tr -dc "A-Z2-7" </dev/urandom | head -c 32)"; then
+	if ! totp_secret="$(dd if=/dev/urandom bs=1 count=20 status=none | base32)"; then
 		d_styled --title "$otp_title" --msgbox $"Failed to generate TOTP secret" 6 45 || :
 		return 1
 	fi


### PR DESCRIPTION
* otp: Use more obvious dd | base32 instead of tr | head
* otp: Use the system nodename as issuer in the QR code