### PR TITLE
Use xterm on WSL based hosts boo#1237756

### DIFF
--- a/files/usr/share/jeos-firstboot/welcome-screen
+++ b/files/usr/share/jeos-firstboot/welcome-screen
@@ -48,8 +48,13 @@ on_all_consoles() {
 	# Needed to tell apart errors and escape
 	export DIALOG_ERROR=254
 	# The linux fbcon uses this, most serial consoles should be fine too
-	export TERM=linux
-
+	# Use xterm on WSL otherwise Windows 10 cmd.exe
+	# will run into issues with encoding in both text and borders
+	if grep -qiw 'microsoft' /proc/version 2>/dev/null; then
+		export TERM=xterm-256color
+	else
+		export TERM=linux
+	fi
 	# Create a FIFO for communicating the status
 	fifodir="$(mktemp -d)"
 	mkfifo "${fifodir}/fifo"


### PR DESCRIPTION
* Fixes issue with invalid encoding in WSL/Windows 10 cmd.exe
* We don't do systemd trigger, therefore the system ENV can stick with TERM=linux

![image](https://github.com/user-attachments/assets/54c58456-213d-4deb-98d8-9a4680bd467a)


After the change

![image](https://github.com/user-attachments/assets/61e3570f-b9c2-4132-b7c3-e4f90e6e21c3)


