### PR TITLE
Add ConditionFirstBoot as alternative trigger for firstboot services

### DIFF
--- a/files/usr/lib/systemd/system/jeos-firstboot-snapshot.service
+++ b/files/usr/lib/systemd/system/jeos-firstboot-snapshot.service
@@ -9,7 +9,8 @@ After=apparmor.service local-fs.target plymouth-start.service YaST2-Second-Stage
 Conflicts=plymouth-start.service
 Before=getty@tty1.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service
 Before=display-manager.service
-ConditionPathExists=/var/lib/YaST2/reconfig_system
+ConditionPathExists=|/var/lib/YaST2/reconfig_system
+ConditionFirstBoot=|yes
 # The configuration is already done - so this doesn't make much sense
 #OnFailure=poweroff.target
 

--- a/files/usr/lib/systemd/system/jeos-firstboot-snapshot.service
+++ b/files/usr/lib/systemd/system/jeos-firstboot-snapshot.service
@@ -25,6 +25,7 @@ Type=oneshot
 RemainAfterExit=yes
 # In Pre - if creation fails, don't do the configuration again
 ExecStartPre=/usr/bin/rm -f /var/lib/YaST2/reconfig_system
+ExecStartPre=/usr/bin/rm -rf /var/lib/combustion/done
 ExecStart=/usr/sbin/jeos-firstboot-snapshot
 
 [Install]

--- a/files/usr/lib/systemd/system/jeos-firstboot-snapshot.service
+++ b/files/usr/lib/systemd/system/jeos-firstboot-snapshot.service
@@ -25,7 +25,6 @@ Type=oneshot
 RemainAfterExit=yes
 # In Pre - if creation fails, don't do the configuration again
 ExecStartPre=/usr/bin/rm -f /var/lib/YaST2/reconfig_system
-ExecStartPre=/usr/bin/rm -rf /var/lib/combustion/done
 ExecStart=/usr/sbin/jeos-firstboot-snapshot
 
 [Install]

--- a/files/usr/lib/systemd/system/jeos-firstboot.service
+++ b/files/usr/lib/systemd/system/jeos-firstboot.service
@@ -9,7 +9,8 @@ After=apparmor.service local-fs.target plymouth-start.service YaST2-Second-Stage
 Conflicts=plymouth-start.service
 Before=getty@tty1.service serial-getty@hvc0.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service serial-getty@ttyAMA0.service
 Before=display-manager.service
-ConditionPathExists=/var/lib/YaST2/reconfig_system
+ConditionPathExists=|/var/lib/YaST2/reconfig_system
+ConditionFirstBoot=|yes
 OnFailure=poweroff.target
 
 # jeos-firstboot starts before wicked and login though.

--- a/files/usr/sbin/jeos-firstboot
+++ b/files/usr/sbin/jeos-firstboot
@@ -38,6 +38,16 @@ if [ -e /run/cloud-init/enabled ] && ! grep -qw none /run/cloud-init/cloud-id; t
 	exit 0
 fi
 
+if [ -e /etc/.ignition-result.json ] && grep -q '"userConfigProvided":.*true' /etc/.ignition-result.json; then
+	echo $"System configured with ignition, skipping jeos-firstboot"
+	exit 0
+fi
+
+if [ -e /var/lib/combustion/done ]; then
+	echo $"System configured with combustion, skipping jeos-firstboot"
+	exit 0
+fi
+
 if [ -n "$dry" ]; then
 	run() {
 		echo "$@"

--- a/files/usr/sbin/jeos-firstboot
+++ b/files/usr/sbin/jeos-firstboot
@@ -43,7 +43,7 @@ if [ -e /etc/.ignition-result.json ] && grep -q '"userConfigProvided":.*true' /e
 	exit 0
 fi
 
-if [ -e /var/lib/combustion/done ]; then
+if [ -e /etc/.combustion-result.json ]; then
 	echo $"System configured with combustion, skipping jeos-firstboot"
 	exit 0
 fi


### PR DESCRIPTION
- Add `ConditionFirstBoot=|yes` alongside `ConditionPathExists=|/var/lib/YaST2/reconfig_system` to both `jeos-firstboot.service` and `jeos-firstboot-snapshot.service`
- The `|` prefix makes them OR conditions, so the service triggers if either condition is met
- This removes the need to create `/var/lib/YaST2/reconfig_system` for image builds where systemd's built-in first boot detection is sufficient
- Backward compatibility with YaST2 and manual reconfiguration is preserved

### Ignition/Combustion compatibility

To prevent the firstboot wizard from running on systems already configured by ignition or combustion, runtime guards are added in `/usr/sbin/jeos-firstboot`:

- **Ignition**: Checks `/etc/.ignition-result.json` for `userConfigProvided: true` (mirrors the logic in `ignition-remove-reconfig_system.service`)
- **Combustion**: Checks for `/var/lib/combustion/done` marker file (requires a corresponding change in `openSUSE/combustion` to write this marker when running with `--complete`)
- The combustion marker is cleaned up by `jeos-firstboot-snapshot.service` alongside the existing `/var/lib/YaST2/reconfig_system` removal

Fixes #98
